### PR TITLE
🔨 build(clean): Remove generated files on clean

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -18,6 +18,7 @@
     "stylelint",
     "stylesheet",
     "TJQK",
+    "tsbuildinfo",
     "Vite"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "audit": "better-npm-audit audit",
     "build": "vite build",
     "start": "vite",
-    "clean": "rm -rf dist coverage storybook-static",
+    "clean": "rm -rf coverage/ dist/ playwright-report/ storybook-static/ test-results/ tsconfig.tsbuildinfo",
     "storybook": "storybook dev -p 6006",
     "test-storybook": "storybook build && npx --no-install concurrently --kill-others --success first --names 'Storybook,Test' 'npx --no-install http-server storybook-static --port 6006 --silent > /dev/null 2>&1 | tail -f /dev/null' 'npx --no-install wait-on --timeout 1s tcp:6006 && test-storybook --browsers chromium webkit firefox'"
   },


### PR DESCRIPTION
Somehow missed coverage/, playwright-report/, test-results/ (empty) and tsconfig.tsbuildinfo during previous development work.