### PR TITLE
🚀 ci(main): Don't retest merged PRs on deploy

### DIFF
--- a/.github/workflows/npm-build-test-upload-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-and-deploy.yml
@@ -1,7 +1,7 @@
-name: npm-test-build-upload-and-deploy-to-pages
+name: npm-build-test-upload-and-deploy
 on: [push]
 jobs:
-  npm-test-build-and-upload-artifact:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -10,33 +10,38 @@ jobs:
           node-version-file: ".nvmrc"
       - name: Install dependencies
         run: npm clean-install
+      - name: Build web application bundles
+        run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref != 'refs/heads/main'
+    steps:
       - name: Run static code and project analyses
         run: npm run lint
       - name: Run unit tests
         run: npm run test
       - name: Install end to end test browsers
-        run: npx --no-install playwright install --with-deps
+        run: npm run playwright-install
       - name: Run Storybook tests
         run: npm run test-storybook
       - name: Run end to end tests
         run: npm run test-e2e
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-      - name: Remove development web application bundles
-        run: npm run clean
-      - name: Build web application bundles
-        run: npm run build
+
+  upload-artifact:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v2
         with:
           path: dist/
 
-  deploy-artifact-to-github-pages:
-    needs: npm-test-build-and-upload-artifact
+  deploy:
+    runs-on: ubuntu-latest
+    needs: upload-artifact
     if: github.ref == 'refs/heads/main'
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
@@ -49,7 +54,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy-to-github-pages.outputs.page_url }}
 
-    runs-on: ubuntu-latest
     steps:
       - id: deploy-to-github-pages
         name: Deploy GitHub Pages site

--- a/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
@@ -1,8 +1,9 @@
-name: npm-build-test-upload-and-deploy
+name: npm-build-test-upload-artifact-and-deploy
 on: [push]
 jobs:
-  build:
+  build-and-upload-artifact:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -12,12 +13,23 @@ jobs:
         run: npm clean-install
       - name: Build web application bundles
         run: npm run build
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist/
 
-  test:
+  build-and-test:
     runs-on: ubuntu-latest
-    needs: build
     if: github.ref != 'refs/heads/main'
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Build web application bundles
+        run: npm run build
       - name: Run static code and project analyses
         run: npm run lint
       - name: Run unit tests
@@ -29,19 +41,9 @@ jobs:
       - name: Run end to end tests
         run: npm run test-e2e
 
-  upload-artifact:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: dist/
-
   deploy:
     runs-on: ubuntu-latest
-    needs: upload-artifact
+    needs: build-and-upload-artifact
     if: github.ref == 'refs/heads/main'
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/markafitzgerald1/cribbage-trainer/npm-build-test-upload-and-deploy.yml?label=build%2Bdeploy&style=plastic)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/markafitzgerald1/cribbage-trainer/npm-build-test-upload-artifact-and-deploy.yml?label=build%2Bdeploy&style=plastic)
 ![GitHub deployments](https://img.shields.io/github/deployments/markafitzgerald1/cribbage-trainer/github-pages?label=deploy&style=plastic)
 ![Website](https://img.shields.io/website?label=webapp%20site&style=plastic&url=https%3A%2F%2Fmarkafitzgerald1.github.io%2Fcribbage-trainer%2F)
 ![GitHub](https://img.shields.io/github/license/markafitzgerald1/cribbage-trainer?style=plastic)
@@ -15,7 +15,7 @@ Code in `main` is automatically built on `git push` and deployed to the [GitHub
 Pages](https://pages.github.com/) hosted
 [Cribbage Trainer app site](https://markafitzgerald1.github.io/cribbage-trainer/)
 on build success via
-[GitHub Action Workflow](https://github.com/markafitzgerald1/cribbage-trainer/actions/workflows/npm-build-test-upload-and-deploy.yml).
+[GitHub Action Workflow](https://github.com/markafitzgerald1/cribbage-trainer/actions/workflows/npm-build-test-upload-artifact-and-deploy.yml).
 
 ## Local and Development Setup
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/markafitzgerald1/cribbage-trainer/npm-parcel-build-upload-and-deploy-to-pages.yml?label=build%2Bdeploy&style=plastic)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/markafitzgerald1/cribbage-trainer/npm-build-test-upload-and-deploy.yml?label=build%2Bdeploy&style=plastic)
 ![GitHub deployments](https://img.shields.io/github/deployments/markafitzgerald1/cribbage-trainer/github-pages?label=deploy&style=plastic)
 ![Website](https://img.shields.io/website?label=webapp%20site&style=plastic&url=https%3A%2F%2Fmarkafitzgerald1.github.io%2Fcribbage-trainer%2F)
 ![GitHub](https://img.shields.io/github/license/markafitzgerald1/cribbage-trainer?style=plastic)
@@ -15,7 +15,7 @@ Code in `main` is automatically built on `git push` and deployed to the [GitHub
 Pages](https://pages.github.com/) hosted
 [Cribbage Trainer app site](https://markafitzgerald1.github.io/cribbage-trainer/)
 on build success via
-[GitHub Action Workflow](https://github.com/markafitzgerald1/cribbage-trainer/actions/workflows/npm-parcel-build-upload-and-deploy-to-pages.yml).
+[GitHub Action Workflow](https://github.com/markafitzgerald1/cribbage-trainer/actions/workflows/npm-build-test-upload-and-deploy.yml).
 
 ## Local and Development Setup
 


### PR DESCRIPTION
They're already required to pass tests in PRs and PRs must be up to date with mai before merging into main, thus re-running the tests is fully redundant.