### PR TITLE
🔨 build(artifact): use github-pages environment

### DIFF
--- a/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
@@ -4,6 +4,7 @@ jobs:
   build-and-upload-artifact:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    environment: github-pages
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Doing this to access the needed VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID environment variable to enable Google Analytics in the GitHub Pages environment.