### PR TITLE
🔨 build(artifact): remove GA measurement ID reset

### DIFF
--- a/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
@@ -14,8 +14,6 @@ jobs:
         run: npm clean-install
       - name: Build web application bundles
         run: npm run build
-        env:
-          VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ env.VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID }}
       - name: Build static Storybook site
         run: npm run storybook:build
       - name: Upload GitHub Pages artifact


### PR DESCRIPTION
Extra YML was resetting environment variable already set in the github-pages GitHub environment.