### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.ref != 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/markafitzgerald1/cribbage-trainer/security/code-scanning/1](https://github.com/markafitzgerald1/cribbage-trainer/security/code-scanning/1)

To fix the issue, we need to explicitly define the `permissions` block for the `build-and-test` job. Since this job only requires read access to the repository contents, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to perform the tasks in this job.

The `permissions` block should be added at the job level, immediately after the `runs-on` key in the `build-and-test` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
