### PR TITLE
fix: use npm semver syntax for eslint ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
           - "*"
     ignore:
       - dependency-name: "eslint"
-        versions: [">= 10.0.0, <= 10.2.1"]
+        versions: [">=10.0.0 <=10.2.1"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Codex identified that npm requires space-separated comparators for ranges rather than commas. Updated dependabot.yml to use ">=10.0.0 <=10.2.1" to ensure the ignore rule applies correctly.