### PR TITLE
docs: Add AI Code Provenance Notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ on build success via [GitHub Action Workflow](https://github.com/markafitzgerald
 
 Before making changes, all developers and AI agents must read
 [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
+
+## License & AI Provenance
+
+This project utilizes AI coding assistants in its development. All AI-generated
+code is rigorously reviewed, tested, and modified by human maintainers. The
+compiled repository and all its contents are distributed under the Mozilla
+Public License 2.0 (MPL 2.0). See the [LICENSE](LICENSE) file for more details.


### PR DESCRIPTION
Add an AI Code Provenance disclaimer to the project's README.md to explicitly state that AI-generated code is human-reviewed and distributed under the project's MPL 2.0 license. This ensures transparency and compliance with licensing policies regarding AI coding assistants.

---
*PR created automatically by Jules for task [10099377989059042864](https://jules.google.com/task/10099377989059042864) started by @markafitzgerald1*