### PR TITLE
chore(deps): group playwright dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+multi-ecosystem-groups:
+  playwright-sync:
+    schedule:
+      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
@@ -16,7 +20,22 @@ updates:
     ignore:
       - dependency-name: "eslint"
         versions: [">=10.0.0 <=10.3.0"]
+      - dependency-name: "playwright"
+      - dependency-name: "@playwright/test"
+  - package-ecosystem: "npm"
+    directory: "/"
+    multi-ecosystem-group: "playwright-sync"
+    allow:
+      - dependency-name: "playwright"
+      - dependency-name: "@playwright/test"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "mcr.microsoft.com/playwright"
+  - package-ecosystem: "docker"
+    directory: "/"
+    multi-ecosystem-group: "playwright-sync"
+    allow:
+      - dependency-name: "mcr.microsoft.com/playwright"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,19 +28,19 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     multi-ecosystem-group: "playwright-sync"
-    patterns:
-      - "playwright"
-      - "@playwright/test"
+    allow:
+      - dependency-name: "playwright"
+      - dependency-name: "@playwright/test"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "playwright"
+      - dependency-name: "mcr.microsoft.com/playwright"
 
   - package-ecosystem: "docker"
     directory: "/"
     multi-ecosystem-group: "playwright-sync"
-    patterns:
-      - "playwright"
+    allow:
+      - dependency-name: "mcr.microsoft.com/playwright"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,19 +28,19 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     multi-ecosystem-group: "playwright-sync"
-    allow:
-      - dependency-name: "playwright"
-      - dependency-name: "@playwright/test"
+    patterns:
+      - "playwright"
+      - "@playwright/test"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "mcr.microsoft.com/playwright"
+      - dependency-name: "playwright"
 
   - package-ecosystem: "docker"
     directory: "/"
     multi-ecosystem-group: "playwright-sync"
-    allow:
-      - dependency-name: "mcr.microsoft.com/playwright"
+    patterns:
+      - "playwright"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 version: 2
+
 multi-ecosystem-groups:
   playwright-sync:
     schedule:
-      interval: "weekly"
+      interval: "daily"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
@@ -22,20 +24,23 @@ updates:
         versions: [">=10.0.0 <=10.3.0"]
       - dependency-name: "playwright"
       - dependency-name: "@playwright/test"
+
   - package-ecosystem: "npm"
     directory: "/"
     multi-ecosystem-group: "playwright-sync"
-    allow:
-      - dependency-name: "playwright"
-      - dependency-name: "@playwright/test"
+    patterns:
+      - "playwright"
+      - "@playwright/test"
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "mcr.microsoft.com/playwright"
+      - dependency-name: "playwright"
+
   - package-ecosystem: "docker"
     directory: "/"
     multi-ecosystem-group: "playwright-sync"
-    allow:
-      - dependency-name: "mcr.microsoft.com/playwright"
+    patterns:
+      - "playwright"


### PR DESCRIPTION
This PR groups npm (`playwright`, `@playwright/test`) and Docker (`mcr.microsoft.com/playwright`) Dependabot updates into a single `playwright-sync` multi-ecosystem-group. This resolves the CI issue where separate PRs for these components would cause CI to fail because of strict version parity required between the npm package and browser binaries.

---
*PR created automatically by Jules for task [17605254625664991087](https://jules.google.com/task/17605254625664991087) started by @markafitzgerald1*