### PR TITLE
[codex] Ignore ESLint 10.4 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
           - "*"
     ignore:
       - dependency-name: "eslint"
-        versions: [">=10.0.0 <=10.3.0"]
+        versions: [">=10.0.0 <=10.4.0"]
       - dependency-name: "playwright"
       - dependency-name: "@playwright/test"
 


### PR DESCRIPTION
## Summary

- Extend the Dependabot ESLint ignore range through `10.4.0`.
- Keep other Dependabot dependency updates flowing normally.

## Root cause

`eslint@10.4.0` conflicts with `eslint-plugin-jsx-a11y@6.10.2`, which only
declares peer support through ESLint 9.

## Validation

- `npm run docker:build-and-test-all`

_(above all authored by Codex GPT-5.5 (medium) under my direction and supervision)_