### PR TITLE
Add semantic Playwright e2e test for suited analysis flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,12 @@
 - Never use inline `CSpell:ignore` comments; instead add words to `.cspell.json`.
 - Prefer small, focused commits; summarize why changes are needed.
 - Only comment on the "why" behind code; strongly prefer meaningful test names,
-  function names, and variable names to comments in code.
+  function names, and variable names to comments in code. Do not add redundant
+  comments explaining self-evident code (e.g., in e2e tests).
+- Extract duplicated object literals (like `{ exact: true }`) into variables to
+  reduce code duplication.
+- Ensure all pull request review comments are resolved in GitHub after addressing
+  and responding to them.
 - Use long-form flags for command-line tools (e.g., `git commit --message` not
   `git commit -m`, `ls --all` not `ls -a`) to improve readability and
   understanding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@
 - Prefer small, focused commits; summarize why changes are needed.
 - Only comment on the "why" behind code; strongly prefer meaningful test names,
   function names, and variable names to comments in code. Do not add redundant
-  comments explaining self-evident code (e.g., in e2e tests).
+  comments explaining self-evident code.
 - Extract duplicated object literals (like `{ exact: true }`) into variables to
   reduce code duplication.
 - Ensure all pull request review comments are resolved in GitHub after addressing

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
         "@eslint/compat": "^2.1.0",
+        "@eslint/eslintrc": "^3.3.5",
         "@jest/globals": "^30.4.1",
         "@playwright/test": "^1.60.0",
         "@storybook/addon-docs": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@eslint/compat": "^2.1.0",
+    "@eslint/eslintrc": "^3.3.5",
     "@jest/globals": "^30.4.1",
     "@playwright/test": "^1.60.0",
     "@storybook/addon-docs": "^10.4.0",

--- a/tests-e2e/index.spec.ts
+++ b/tests-e2e/index.spec.ts
@@ -81,5 +81,5 @@ test("semantic e2e suited analysis flow", async ({ page }) => {
   await page.getByText("Starter avg").click();
 
   // Assert that the starter-specific cut details expand and are visible
-  await expect(page.locator("tbody").getByText("Points", { exact: true })).toBeVisible();
+  await expect(page.locator('div[class*="cut-result-row"]').first()).toBeVisible();
 });

--- a/tests-e2e/index.spec.ts
+++ b/tests-e2e/index.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { type Locator, type Page, expect, test } from "@playwright/test";
 import { renderThenSelectTwoDiscards } from "./renderThenSelectTwoDiscards";
 
 const expectedHtmlLanguage = "en";
@@ -38,6 +38,29 @@ test("a .css file is linked", async ({ page }) => {
 });
 
 const constantHandQuery = "?hand=KH,QS,10D,9C,6S,5H";
+const selectedDiscardRowText = "K♥Q♠10♦9♣(6♠5♥)";
+const exactTextMatch = { exact: true };
+const expectedBreakdownLabels = [
+  "15s",
+  "Pairs",
+  "Runs",
+  "Flushes",
+  "Nobs",
+  "Total",
+] as const;
+
+const getSelectedDiscardRow = (page: Page) =>
+  page
+    .locator('tr[class*="highlighted"]')
+    .filter({ hasText: selectedDiscardRowText });
+
+const expectBreakdownLabelsVisible = async (tbody: Locator) => {
+  await Promise.all(
+    expectedBreakdownLabels.map(async (label) => {
+      await expect(tbody.getByText(label, exactTextMatch)).toBeVisible();
+    }),
+  );
+};
 
 test("pre-cut hand points show after select of two discards", async ({
   page,
@@ -60,20 +83,12 @@ test("semantic e2e suited analysis flow", async ({ page }) => {
   await page.getByRole("checkbox").nth(indexOf6S).click();
   await page.getByRole("checkbox").nth(indexOf5H).click();
 
-  const row = page.locator("tbody tr").filter({ hasText: "K♥Q♠10♦9♣(6♠5♥)" });
+  const row = getSelectedDiscardRow(page);
   await expect(row).toBeVisible();
 
   await row.click();
 
-  const exactMatch = { exact: true };
-  const partialMatch = { exact: false };
-
-  await expect(page.locator("tbody").getByText("15s", exactMatch)).toBeVisible();
-  await expect(page.locator("tbody").getByText("Pairs", exactMatch)).toBeVisible();
-  await expect(page.locator("tbody").getByText("Runs", exactMatch)).toBeVisible();
-  await expect(page.locator("tbody").getByText("Flush", partialMatch)).toBeVisible();
-  await expect(page.locator("tbody").getByText("Nobs", exactMatch)).toBeVisible();
-  await expect(page.locator("tbody").getByText("Total", exactMatch)).toBeVisible();
+  await expectBreakdownLabelsVisible(page.locator("tbody"));
   await expect(page.getByText("Starter avg")).toBeVisible();
 
   await page.getByText("Starter avg").click();

--- a/tests-e2e/index.spec.ts
+++ b/tests-e2e/index.spec.ts
@@ -51,3 +51,35 @@ test("pre-cut hand points show after select of two discards", async ({
     page.getByRole("columnheader", { exact: true, name: "Cut" }),
   ).toBeVisible();
 });
+
+test("semantic e2e suited analysis flow", async ({ page }) => {
+  await page.goto("/?hand=KH,QS,10D,9C,6S,5H");
+
+  // Click the 6S and 5H cards to select them for discard
+  const indexOf6S = 4;
+  const indexOf5H = 5;
+  await page.getByRole("checkbox").nth(indexOf6S).click();
+  await page.getByRole("checkbox").nth(indexOf5H).click();
+
+  // Assert that the expected row correctly renders the suited keep labels (K♥ Q♠ 10♦ 9♣) and discard labels (6♠ 5♥)
+  const row = page.locator("tbody tr").filter({ hasText: "K♥Q♠10♦9♣(6♠5♥)" });
+  await expect(row).toBeVisible();
+
+  // Expand that first result row
+  await row.click();
+
+  // Assert that the breakdown headers are visible in the DOM
+  await expect(page.locator("tbody").getByText("15s", { exact: true })).toBeVisible();
+  await expect(page.locator("tbody").getByText("Pairs", { exact: true })).toBeVisible();
+  await expect(page.locator("tbody").getByText("Runs", { exact: true })).toBeVisible();
+  await expect(page.locator("tbody").getByText("Flush", { exact: false })).toBeVisible();
+  await expect(page.locator("tbody").getByText("Nobs", { exact: true })).toBeVisible();
+  await expect(page.locator("tbody").getByText("Total", { exact: true })).toBeVisible();
+  await expect(page.getByText("Starter avg")).toBeVisible();
+
+  // Click the 'Starter avg' header
+  await page.getByText("Starter avg").click();
+
+  // Assert that the starter-specific cut details expand and are visible
+  await expect(page.locator("tbody").getByText("Points", { exact: true })).toBeVisible();
+});

--- a/tests-e2e/index.spec.ts
+++ b/tests-e2e/index.spec.ts
@@ -55,31 +55,30 @@ test("pre-cut hand points show after select of two discards", async ({
 test("semantic e2e suited analysis flow", async ({ page }) => {
   await page.goto("/?hand=KH,QS,10D,9C,6S,5H");
 
-  // Click the 6S and 5H cards to select them for discard
   const indexOf6S = 4;
   const indexOf5H = 5;
   await page.getByRole("checkbox").nth(indexOf6S).click();
   await page.getByRole("checkbox").nth(indexOf5H).click();
 
-  // Assert that the expected row correctly renders the suited keep labels (K♥ Q♠ 10♦ 9♣) and discard labels (6♠ 5♥)
   const row = page.locator("tbody tr").filter({ hasText: "K♥Q♠10♦9♣(6♠5♥)" });
   await expect(row).toBeVisible();
 
-  // Expand that first result row
   await row.click();
 
-  // Assert that the breakdown headers are visible in the DOM
-  await expect(page.locator("tbody").getByText("15s", { exact: true })).toBeVisible();
-  await expect(page.locator("tbody").getByText("Pairs", { exact: true })).toBeVisible();
-  await expect(page.locator("tbody").getByText("Runs", { exact: true })).toBeVisible();
-  await expect(page.locator("tbody").getByText("Flush", { exact: false })).toBeVisible();
-  await expect(page.locator("tbody").getByText("Nobs", { exact: true })).toBeVisible();
-  await expect(page.locator("tbody").getByText("Total", { exact: true })).toBeVisible();
+  const exactMatch = { exact: true };
+  const partialMatch = { exact: false };
+
+  await expect(page.locator("tbody").getByText("15s", exactMatch)).toBeVisible();
+  await expect(page.locator("tbody").getByText("Pairs", exactMatch)).toBeVisible();
+  await expect(page.locator("tbody").getByText("Runs", exactMatch)).toBeVisible();
+  await expect(page.locator("tbody").getByText("Flush", partialMatch)).toBeVisible();
+  await expect(page.locator("tbody").getByText("Nobs", exactMatch)).toBeVisible();
+  await expect(page.locator("tbody").getByText("Total", exactMatch)).toBeVisible();
   await expect(page.getByText("Starter avg")).toBeVisible();
 
-  // Click the 'Starter avg' header
   await page.getByText("Starter avg").click();
 
-  // Assert that the starter-specific cut details expand and are visible
-  await expect(page.locator('div[class*="cut-result-row"]').first()).toBeVisible();
+  await expect(
+    page.locator('div[class*="cut-result-row"]').first(),
+  ).toBeVisible();
 });


### PR DESCRIPTION
Fixes #594 by implementing a targeted Playwright e2e test matching the requested test sequence for the suited analysis flow.

---
*PR created automatically by Jules for task [14005926771451922652](https://jules.google.com/task/14005926771451922652) started by @markafitzgerald1*