### PR TITLE
[codex] docs: capture review cleanup lessons

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -25,6 +25,7 @@
     "nums",
     "nvmrc",
     "radiogroup",
+    "regen",
     "rerender",
     "rerenders",
     "rhysd",
@@ -33,6 +34,7 @@
     "stylelint",
     "stylelintignore",
     "stylesheet",
+    "subshells",
     "TJQK",
     "tsbuildinfo",
     "Vite"

--- a/.cspell.json
+++ b/.cspell.json
@@ -25,7 +25,6 @@
     "nums",
     "nvmrc",
     "radiogroup",
-    "regen",
     "rerender",
     "rerenders",
     "rhysd",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,50 @@
     `npm run docker:build-and-test-all -- -- --update-snapshots`.
   - In PRs, explicitly note the screenshot updates and ensure expected images
     are updated to match the current actuals (these will be human reviewed).
+  - `npm run docker:update-screenshots` expands to
+    `docker build ... && docker run ... --update-snapshots`. If the build's
+    lint/Storybook-coverage step fails, the `&&` short-circuits and the
+    baselines are silently NOT rewritten. Confirm the build passed (or that
+    `git status` actually shows changed `tests-e2e` images) before assuming the
+    regen took effect.
+
+## Playwright and UI-layout debugging
+
+- `getByRole(role, { name })` matches the accessible name as a
+  **case-insensitive substring**, not an exact string. A header/button label
+  that is a substring of another control's name causes strict-mode collisions
+  (e.g. a sort label containing "crib" also matched the "Crib" button; "Deal" is
+  a substring of "dealer"; "Net"/"Hand"/"Play" likewise collide if reused in
+  prose). Keep visible and aria labels mutually non-substring. Note Testing
+  Library's `getByRole` uses exact/regex matching, so the same name can pass in
+  Jest yet fail the Playwright strict-mode locator.
+- CSS-module class names are hashed at build time, so a `page.evaluate`-injected
+  `<style>` that targets literal selectors like `.hand-column` silently no-ops.
+  To trial layout variants, edit the real `*.module.css` (Vite HMR applies it
+  live) and re-measure — do not inject literal-class overrides.
+- To diagnose numeric-column alignment, measure rendered glyph bounds with a
+  `Range` over the cell (`range.selectNodeContents(td)` then
+  `getBoundingClientRect().right`) and compare a positive vs a negative row; the
+  `td`'s own right edge will not reveal the gap.
+
+## Discard-table layout (portrait)
+
+- The per-row expand arrow (▸) lives inside the hand/discard cell, which is
+  `overflow: hidden`. Narrowing the portrait hand column too far clips the arrow
+  even when the cards still appear to fit. Keep the column wide enough for
+  cards + parens + arrow; verify with
+  `cell.scrollWidth - cell.clientWidth === 0`.
+- Signed expected-points columns rely on the U+2212 minus (digit-width under
+  tabular-nums) so positives and negatives right-align. Do not try to pad
+  positives with a figure space (U+2007) — it is narrower than U+2212 and
+  would also push 2-digit positives wider than the negatives. Instead size the
+  column so the widest signed-negative value fits without overflowing into the
+  gutter: an oversized score font makes 5-glyph negatives bleed a few px past
+  4-glyph positives, breaking decimal alignment (portrait only, where columns
+  are tightest).
+- A phone-width portrait viewport cannot fit enlarged scores alongside six
+  mini-cards, the arrow, and four numeric columns. Meaningful score-size
+  increases need the horizontal-mini-card redesign, not portrait font bumps.
 
 ## Code style and conventions
 
@@ -156,6 +200,10 @@
 - Resolve pull request review threads after addressing and responding to them.
 - Agents should not need individual review URLs once the repository and PR
   number are known.
+- The `gh` binary may not be on PATH inside piped or compound subshells (e.g. a
+  `while` loop fed by a pipe), failing with `gh: command not found`. Use the
+  absolute path (`/opt/homebrew/bin/gh`) and drive loops from a file
+  (`done < file`) rather than a pipe.
 
 ## Husky/hooks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,12 @@
 - Lint: `npm run lint` (if present) or rely on the Docker test-all command above.
 - Storybook coverage: run `npm run storybook:test:coverage`, then update the
   Vite `test.coverage.thresholds` block to the exact reported totals.
+- For focused Jest/debug runs, pass `--coverage=false` when you only need
+  targeted test signal; global coverage thresholds can make otherwise passing
+  `--runTestsByPath` suites exit nonzero.
+- If `npm run docker:build-and-test-all` is interrupted after build, lint, and
+  Storybook coverage have passed, rerun `npm run docker:run-e2e-only` against
+  the built image to verify the Playwright tail before reporting final status.
 
 ## Dependency maintenance
 
@@ -74,6 +80,9 @@
   `npm run table:update:play` for only the pegging artifact.
 - The browser may look up and combine the shipped means, but must not perform
   pegging Monte Carlo, game-tree search, or policy improvement.
+- Shared expected-points table loaders use `null` to represent absence. Do not
+  use truthiness checks for cached or injected tables, because generic loader
+  callers may validly load falsy values such as `0`, `""`, or `false`.
 
 ## Visual regression updates
 
@@ -111,6 +120,9 @@
   comments explaining self-evident code.
 - Extract duplicated object literals (like `{ exact: true }`) into variables to
   reduce code duplication.
+- When formatting signed expected values, round to display precision before
+  applying sign or minus-glyph formatting so values that round to zero display
+  as `0.00` instead of negative zero.
 - Use long-form flags for command-line tools (e.g., `git commit --message` not
   `git commit -m`, `ls --all` not `ls -a`) to improve readability and
   understanding.
@@ -125,6 +137,9 @@
   GitHub integration or the `gh` CLI for the repository and PR number.
 - With the `gh` CLI, use `gh api graphql` to query review thread fields such as
   `isResolved`, `isOutdated`, and nested comments.
+- After replying to addressed review threads, use the GraphQL
+  `resolveReviewThread` mutation and then reread thread state to confirm
+  `isResolved: true`.
 - Inspect each thread's resolved/outdated state, path, line, and comments before
   deciding whether it still needs code, a reply, or resolution.
 - GitHub enforces unresolved review threads as merge blockers in this repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,8 +165,8 @@
 - Extract duplicated object literals (like `{ exact: true }`) into variables to
   reduce code duplication.
 - When formatting signed expected values, round to display precision before
-  applying sign or minus-glyph formatting so values that round to zero display
-  as `0.00` instead of negative zero.
+  applying sign or minus-glyph formatting (whether a leading `+` or `-`), so
+  values that round to zero display as a plain `0.00`, never `+0.00` or `-0.00`.
 - Use long-form flags for command-line tools (e.g., `git commit --message` not
   `git commit -m`, `ls --all` not `ls -a`) to improve readability and
   understanding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@
     lint/Storybook-coverage step fails, the `&&` short-circuits and the
     baselines are silently NOT rewritten. Confirm the build passed (or that
     `git status` actually shows changed `tests-e2e` images) before assuming the
-    regen took effect.
+    regeneration took effect.
 
 ## Playwright and UI-layout debugging
 

--- a/skills/make-it-green/SKILL.md
+++ b/skills/make-it-green/SKILL.md
@@ -16,3 +16,14 @@ green build status.
 3. Surgically fix any coverage gaps, linting errors, or build failures.
 4. Iterate on this process without human intervention until the build exits with
    code 0.
+
+**Learnings:**
+
+- For focused Jest checks, use
+  `npm test -- --runTestsByPath ... --coverage=false` when you only need
+  targeted signal; global coverage thresholds can make passing targeted suites
+  exit nonzero.
+- If `npm run docker:build-and-test-all` is interrupted after the Docker image
+  build, lint, and Storybook coverage have passed, rerun
+  `npm run docker:run-e2e-only` to verify the remaining Playwright tail before
+  reporting final validation.


### PR DESCRIPTION
## Summary

- Capture durable PR cleanup lessons in `AGENTS.md`.
- Add `make-it-green` notes for targeted Jest checks and interrupted Docker runs.

## Validation

- `npm run lint:markdownlint`
- `npm run lint:prettier`
- `npm run lint:cspell`