### PR TITLE
feat: deep-link the analysis table sort column via analysis-sort param

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,8 @@ local pass is `npm run lint && npm test`.
 - Flag in-code comments that restate the how/what of adjacent code; comments
   should exist only for the non-obvious why (invariants, rationale,
   trade-offs, regression guards).
-- URL query params (`hand`, `role`, `discard`, `sort`, `seed`) are a public
+- URL query params (`hand`, `role`, `discard`, `sort`, `analysis-sort`,
+  `seed`) are a public
   compatibility surface owned by `src/ui/urlAnalysisState.ts`: parsing must
   stay strict-but-soft-failing (return `null`, never throw or crash), and
   changes must keep previously shared links working.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,11 +152,11 @@
 ## URL analysis state (deep linking)
 
 - `src/ui/urlAnalysisState.ts` is the single source of truth for the
-  URL-parameter contract (`hand`, `role`, `discard`, `sort`, `seed`). Its
-  parse functions validate strictly but fail soft (return `null`, never
-  throw), and serialization writes normalized card text (rank label + suit
-  letter) in deal order — never generated object identity or sort-dependent
-  keys.
+  URL-parameter contract (`hand`, `role`, `discard`, `sort`, `analysis-sort`,
+  `seed`). Its parse functions validate strictly but fail soft (return
+  `null`, never throw), and serialization writes normalized card text (rank
+  label + suit letter) in deal order — never generated object identity or
+  sort-dependent keys.
 - URL param values are a public compatibility surface: shared links must keep
   working. Change them only additively and keep parsing backward compatible.
 - History semantics in `Trainer`: before changing state, interactions check
@@ -164,15 +164,17 @@
   discards or a complete discard). Stable states are preserved with
   `pushState`; transient single-card selections are `replaceState`d away, so
   history only ever holds stable states and Back steps 2 discards → 0 →
-  prior hand. Each pushed entry stores the covered entry's URL in
-  `history.state.previousUrl`; when a transient settle converges back onto
-  that URL, `Trainer` calls `history.back()` instead of `replaceState` so a
-  mind-change toggle does not leave an adjacent duplicate entry that turns
-  Back into a no-op (the abandoned transient survives only as a Forward
-  entry). `replaceState` must pass `window.history.state` through — not
-  `null` — so `previousUrl` survives settling. `replaceState` also
-  normalizes the URL on initial mount, and a `popstate` listener re-hydrates
-  full state. Do not replace-away a state the user could want to Back to:
+  prior hand. Analysis-table sort changes can only happen in a stable
+  (complete-discard) state, so each pushes. Each pushed entry stores the
+  covered entry's URL in `history.state.previousUrl`; when a transient
+  settle converges back onto that URL, `Trainer` calls `history.back()`
+  instead of `replaceState` so a mind-change toggle does not leave an
+  adjacent duplicate entry that turns Back into a no-op (the abandoned
+  transient survives only as a Forward entry). `replaceState` must pass
+  `window.history.state` through — not `null` — so `previousUrl` survives
+  settling. `replaceState` also normalizes the URL on initial mount, and a
+  `popstate` listener re-hydrates full state. Do not replace-away a state
+  the user could want to Back to:
   replacing on the first interaction overwrote the only history entry and
   made Back exit the site. The role random draw is skipped only when a valid
   `role` param is present, preserving seeded-workflow behavior.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -324,10 +324,10 @@ export default [
   },
   ...compat.extends("plugin:jest/all").map((config) => ({
     ...config,
-    files: ["**/*.test.ts*", "**/*.stories.ts*"],
+    files: ["**/*.test.ts*", "**/*.test.common.ts*", "**/*.stories.ts*"],
   })),
   {
-    files: ["**/*.test.ts*", "**/*.stories.ts*"],
+    files: ["**/*.test.ts*", "**/*.test.common.ts*", "**/*.stories.ts*"],
     plugins: {
       jest,
     },

--- a/jest.config.json
+++ b/jest.config.json
@@ -5,6 +5,7 @@
     "!src/**/*.d.ts",
     "!src/game/parseCards.common.ts",
     "!src/ui-react/handToSortedString.test.common.ts",
+    "!src/ui-react/Trainer.test.common.tsx",
     "!src/ui-react/*.stories.{ts,tsx}",
     "!src/ui-react/stories.common.ts"
   ],

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ const {
   initialCards,
   initialCribRole,
   initialDiscards,
+  initialScoreSortKey,
   initialSortOrder,
   seed,
 } = getInitialProps(window.location.search);
@@ -21,6 +22,7 @@ ReactDOMClient.createRoot(document.querySelector("#trainer")!).render(
       initialCards={initialCards}
       initialCribRole={initialCribRole}
       initialDiscards={initialDiscards}
+      initialScoreSortKey={initialScoreSortKey}
       initialSortOrder={initialSortOrder}
       loadGoogleAnalytics={handleLoadGoogleAnalytics}
     />

--- a/src/ui-react/ScoredPossibleKeepDiscards.stories.ts
+++ b/src/ui-react/ScoredPossibleKeepDiscards.stories.ts
@@ -12,10 +12,11 @@ import {
   toDealtCards,
   waitForLoadingToDisappear,
 } from "./stories.common";
-import { expect, fireEvent, within } from "storybook/test";
+import { expect, fireEvent, fn, within } from "storybook/test";
 import { CARDS } from "../game/Card";
 import { CribRole } from "../game/expectedCribPoints";
 import type { DealtCard } from "../game/DealtCard";
+import { ScoredKeepDiscardSortKey } from "../analysis/compareByExpectedScoreDescending";
 import { ScoredPossibleKeepDiscards } from "./ScoredPossibleKeepDiscards";
 /* jscpd:ignore-end */
 
@@ -52,6 +53,8 @@ const createStory = (dealtCards: DealtCard[], sortOrder: SortOrder): Story => ({
   args: {
     cribRole: CribRole.Dealer,
     dealtCards,
+    onScoreSortKeyChange: fn(),
+    scoreSortKey: ScoredKeepDiscardSortKey.ExpectedNetPoints,
     sortOrder,
   },
 });
@@ -97,13 +100,18 @@ export const DoubleExpandedPone: Story = {
 
 export const SortedByHandPoints: Story = {
   ...JackSixFiveFourKingQueenSortedDescending,
+  args: {
+    ...JackSixFiveFourKingQueenSortedDescending.args,
+    scoreSortKey: ScoredKeepDiscardSortKey.ExpectedHandPoints,
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await waitForLoadingToDisappear(canvas);
-    const headerButton = await canvas.findByRole("button", {
-      name: /^Hand:/u,
+    const handHeader = await canvas.findByRole("columnheader", {
+      name: /Hand/u,
     });
-    await fireEvent.click(headerButton);
+
+    await expect(handHeader).toHaveAttribute("aria-sort", "descending");
   },
 };
 

--- a/src/ui-react/ScoredPossibleKeepDiscards.test.tsx
+++ b/src/ui-react/ScoredPossibleKeepDiscards.test.tsx
@@ -10,6 +10,7 @@ import { CARDS_PER_DISCARD } from "../game/facts";
 import { Combination } from "js-combinatorics";
 import type { DealtCard } from "../game/DealtCard";
 import { type ExpectedPlayPointsTable } from "../game/expectedPlayPoints";
+import { ScoredKeepDiscardSortKey } from "../analysis/compareByExpectedScoreDescending";
 import { ScoredPossibleKeepDiscards } from "./ScoredPossibleKeepDiscards";
 import { SortOrder } from "../ui/SortOrder";
 import { dealHand } from "../game/dealHand";
@@ -42,10 +43,23 @@ jest.mock<typeof import("../game/expectedCribPointsTableLoader")>(
 describe("scored possible keep discards component", () => {
   const mathRandom = Math.random;
 
+  interface RenderOptions {
+    readonly cribRole?: CribRole;
+    readonly onScoreSortKeyChange?: (
+      scoreSortKey: ScoredKeepDiscardSortKey,
+    ) => void;
+    readonly preload?: boolean;
+    readonly scoreSortKey?: ScoredKeepDiscardSortKey;
+  }
+
   const renderScoredPossibleKeepDiscards = (
     dealtCards: DealtCard[],
-    cribRole: CribRole = CribRole.Dealer,
-    preload = true,
+    {
+      cribRole = CribRole.Dealer,
+      onScoreSortKeyChange = jest.fn(),
+      preload = true,
+      scoreSortKey = ScoredKeepDiscardSortKey.ExpectedNetPoints,
+    }: RenderOptions = {},
   ) => {
     if (preload) {
       setTableSync(
@@ -60,6 +74,8 @@ describe("scored possible keep discards component", () => {
       <ScoredPossibleKeepDiscards
         cribRole={cribRole}
         dealtCards={dealtCards}
+        onScoreSortKeyChange={onScoreSortKeyChange}
+        scoreSortKey={scoreSortKey}
         sortOrder={SortOrder.Ascending}
       />,
     );
@@ -117,7 +133,9 @@ describe("scored possible keep discards component", () => {
   });
 
   it("labels the net column with the net expected points sort", () => {
-    renderScoredPossibleKeepDiscards(dealHand(mathRandom), CribRole.Pone);
+    renderScoredPossibleKeepDiscards(dealHand(mathRandom), {
+      cribRole: CribRole.Pone,
+    });
 
     expect(
       screen.getByRole("button", { name: "Net: Sort by net expected points" }),
@@ -125,18 +143,19 @@ describe("scored possible keep discards component", () => {
   });
 
   it.each([
-    { cellIndex: 1, headerName: /^Hand:/u },
-    { cellIndex: 2, headerName: /^Crib:/u },
-    { cellIndex: 3, headerName: /^Play:/u },
-    { cellIndex: 4, headerName: /^Net:/u },
+    { cellIndex: 1, scoreSortKey: ScoredKeepDiscardSortKey.ExpectedHandPoints },
+    { cellIndex: 2, scoreSortKey: ScoredKeepDiscardSortKey.ExpectedCribPoints },
+    { cellIndex: 3, scoreSortKey: ScoredKeepDiscardSortKey.ExpectedPlayPoints },
+    { cellIndex: 4, scoreSortKey: ScoredKeepDiscardSortKey.ExpectedNetPoints },
   ])(
-    "sorts rows by $headerName when the score header is clicked",
-    ({ cellIndex, headerName }) => {
+    "sorts rows by the $scoreSortKey score sort key prop",
+    ({ cellIndex, scoreSortKey }) => {
       expect.hasAssertions();
 
-      const { container } = dealAndRender();
-
-      fireEvent.click(screen.getByRole("button", { name: headerName }));
+      const { container } = renderScoredPossibleKeepDiscards(
+        dealHand(mathRandom),
+        { scoreSortKey },
+      );
 
       const values = getColumnValues(container, cellIndex);
 
@@ -146,15 +165,44 @@ describe("scored possible keep discards component", () => {
     },
   );
 
+  it.each([
+    {
+      headerName: /^Hand:/u,
+      scoreSortKey: ScoredKeepDiscardSortKey.ExpectedHandPoints,
+    },
+    {
+      headerName: /^Crib:/u,
+      scoreSortKey: ScoredKeepDiscardSortKey.ExpectedCribPoints,
+    },
+    {
+      headerName: /^Play:/u,
+      scoreSortKey: ScoredKeepDiscardSortKey.ExpectedPlayPoints,
+    },
+    {
+      headerName: /^Net:/u,
+      scoreSortKey: ScoredKeepDiscardSortKey.ExpectedNetPoints,
+    },
+  ])(
+    "notifies the change handler with $scoreSortKey when the $headerName header is clicked",
+    ({ headerName, scoreSortKey }) => {
+      expect.hasAssertions();
+
+      const onScoreSortKeyChange = jest.fn();
+      renderScoredPossibleKeepDiscards(dealHand(mathRandom), {
+        onScoreSortKeyChange,
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: headerName }));
+
+      expect(onScoreSortKeyChange).toHaveBeenCalledWith(scoreSortKey);
+    },
+  );
+
   const renderAndExpectLoading = () => {
     setTableSync(null);
     setPlayTableSync(null);
 
-    renderScoredPossibleKeepDiscards(
-      dealHand(mathRandom),
-      CribRole.Dealer,
-      false,
-    );
+    renderScoredPossibleKeepDiscards(dealHand(mathRandom), { preload: false });
 
     expect(screen.getByText("Loading analysis...")).toBeTruthy();
   };

--- a/src/ui-react/ScoredPossibleKeepDiscards.tsx
+++ b/src/ui-react/ScoredPossibleKeepDiscards.tsx
@@ -32,6 +32,10 @@ export interface ScoredPossibleKeepDiscardsProps {
    */
   readonly loadCribTable?: () => Promise<ExpectedCribPointsTable>;
   readonly loadPlayTable?: () => Promise<ExpectedPlayPointsTable>;
+  readonly onScoreSortKeyChange: (
+    scoreSortKey: ScoredKeepDiscardSortKey,
+  ) => void;
+  readonly scoreSortKey: ScoredKeepDiscardSortKey;
   readonly sortOrder: SortOrder;
 }
 
@@ -83,6 +87,8 @@ export function ScoredPossibleKeepDiscards({
   dealtCards,
   loadCribTable = cribLoader.loadTable,
   loadPlayTable = playLoader.loadTable,
+  onScoreSortKeyChange,
+  scoreSortKey,
   sortOrder,
 }: ScoredPossibleKeepDiscardsProps) {
   const [tables, setTables] = useState<{
@@ -113,9 +119,6 @@ export function ScoredPossibleKeepDiscards({
     setRetryCount((prev) => prev + 1);
   }, []);
 
-  const [scoreSortKey, setScoreSortKey] = useState<ScoredKeepDiscardSortKey>(
-    ScoredKeepDiscardSortKey.ExpectedNetPoints,
-  );
   const scoredKeepDiscardsByNetScore = useMemo(
     () =>
       tables
@@ -136,9 +139,11 @@ export function ScoredPossibleKeepDiscards({
   );
   const handleScoreSortClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
-      setScoreSortKey(event.currentTarget.value as ScoredKeepDiscardSortKey);
+      onScoreSortKeyChange(
+        event.currentTarget.value as ScoredKeepDiscardSortKey,
+      );
     },
-    [],
+    [onScoreSortKeyChange],
   );
 
   if (loadError) {

--- a/src/ui-react/Trainer.stories.tsx
+++ b/src/ui-react/Trainer.stories.tsx
@@ -9,6 +9,7 @@ import { Rank, Suit, createCard } from "../game/Card";
 import { Trainer, analyticsConsentKey } from "./Trainer";
 import { expect, fireEvent, waitFor, within } from "storybook/test";
 import { CribRole } from "../game/expectedCribPoints";
+import { ScoredKeepDiscardSortKey } from "../analysis/compareByExpectedScoreDescending";
 import { createGenerator } from "../game/randomNumberGenerator";
 
 const SEED = "1";
@@ -202,12 +203,36 @@ export const DeepLinkedAnalysisState = {
     ],
     initialCribRole: CribRole.Pone,
     initialDiscards: [SIX_OF_SPADES, FIVE_OF_HEARTS],
+    initialScoreSortKey: ScoredKeepDiscardSortKey.ExpectedHandPoints,
     initialSortOrder: SortOrder.DealOrder,
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     await expect(within(canvasElement).getByText("Pone")).toBeVisible();
 
     await expectAnalysisColumnHeaders(canvasElement);
+
+    const handHeader = within(canvasElement).getByRole("columnheader", {
+      name: /Hand/u,
+    });
+
+    await expect(handHeader).toHaveAttribute("aria-sort", "descending");
+  },
+};
+
+export const SortAnalysisByPlayPoints = {
+  play: async (context: { canvasElement: HTMLElement }) => {
+    await DiscardShowsScoredPossibilities.play(context);
+    const playHeaderButton = within(context.canvasElement).getByRole("button", {
+      name: /^Play:/u,
+    });
+
+    await fireEvent.click(playHeaderButton);
+
+    const playHeader = within(context.canvasElement).getByRole("columnheader", {
+      name: /Play/u,
+    });
+
+    await expect(playHeader).toHaveAttribute("aria-sort", "descending");
   },
 };
 

--- a/src/ui-react/Trainer.test.common.tsx
+++ b/src/ui-react/Trainer.test.common.tsx
@@ -1,0 +1,89 @@
+import {
+  type ByRoleMatcher,
+  type ByRoleOptions,
+  render,
+  screen,
+} from "@testing-library/react";
+import { expect, jest } from "@jest/globals";
+import { CARDS_PER_DEALT_HAND } from "../game/facts";
+import { type ExpectedCribPointsTable } from "../game/expectedCribPoints";
+import { Trainer } from "./Trainer";
+import type { UserEvent } from "@testing-library/user-event";
+import expectedCribPointsTableData from "../game/expectedCribPointsTable.json";
+import { setTableSync } from "../game/expectedCribPointsTableLoader";
+
+export const mathRandom = Math.random;
+const CARD_DRAW_RANDOM_VALUE = 0;
+export const DEALER_RANDOM_VALUE = 0.49;
+export const PONE_RANDOM_VALUE = 0.5;
+
+export const setCribTable = () => {
+  setTableSync(
+    expectedCribPointsTableData as unknown as ExpectedCribPointsTable,
+  );
+};
+
+export const renderTrainerWithGenerator = (
+  generateRandomNumber: () => number,
+) => {
+  setCribTable();
+
+  return render(
+    <Trainer
+      generateRandomNumber={generateRandomNumber}
+      loadGoogleAnalytics={jest.fn()}
+    />,
+  );
+};
+
+export const renderTrainer = () => renderTrainerWithGenerator(mathRandom);
+
+export const createSequenceGenerator = (values: number[]) =>
+  jest.fn(() => values.shift() ?? 0);
+
+const repeatedRandomValues = (value: number): number[] =>
+  Array.from({ length: CARDS_PER_DEALT_HAND }, () => value);
+
+export const createRoleRandomValues = (roleValues: readonly number[]) =>
+  roleValues.flatMap((roleValue) => [
+    ...repeatedRandomValues(CARD_DRAW_RANDOM_VALUE),
+    roleValue,
+  ]);
+
+export const renderTrainerShowingDealerRole = () =>
+  renderTrainerWithGenerator(
+    createSequenceGenerator(createRoleRandomValues([DEALER_RANDOM_VALUE])),
+  );
+
+export const calculationsHeaderName = "Hand";
+
+export const clickIndices = (
+  getAllByRole: (role: ByRoleMatcher, options?: ByRoleOptions) => HTMLElement[],
+  indices: number[],
+  user: UserEvent,
+) =>
+  indices.reduce(
+    (previousClick, index) =>
+      previousClick.then(() => user.click(getAllByRole("checkbox")[index]!)),
+    Promise.resolve(),
+  );
+
+const isRoleLabelVisible = (roleName: string, roleContext: string) =>
+  Boolean(screen.queryByText(roleName)) &&
+  Boolean(screen.queryByText(roleContext));
+
+export const expectDealerRoleVisible = () => {
+  expect(isRoleLabelVisible("Dealer", "your crib")).toBe(true);
+};
+
+export const expectPoneRoleVisible = () => {
+  expect(isRoleLabelVisible("Pone", "opponent crib")).toBe(true);
+};
+
+export const clickDeal = (user: UserEvent) =>
+  user.click(screen.getByRole("button", { name: "Deal" }));
+
+export const getHandText = (container: HTMLElement) =>
+  container.querySelector("ul")!.textContent;
+
+export const SIX_HEARTS_HAND = "AH,2H,3H,4H,5H,6H";

--- a/src/ui-react/Trainer.test.tsx
+++ b/src/ui-react/Trainer.test.tsx
@@ -1,70 +1,29 @@
+/* jscpd:ignore-start */
 import "@testing-library/jest-dom";
-import {
-  type ByRoleMatcher,
-  type ByRoleOptions,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
 import { CARD_LABELS, Rank, type Suit, parseHand } from "../game/Card";
 import { type ComparableCard, sortCards } from "../ui/sortCards";
 import {
-  CribRole,
-  type ExpectedCribPointsTable,
-} from "../game/expectedCribPoints";
+  DEALER_RANDOM_VALUE,
+  PONE_RANDOM_VALUE,
+  SIX_HEARTS_HAND,
+  calculationsHeaderName,
+  clickDeal,
+  clickIndices,
+  createRoleRandomValues,
+  createSequenceGenerator,
+  expectDealerRoleVisible,
+  expectPoneRoleVisible,
+  mathRandom,
+  renderTrainer,
+  renderTrainerShowingDealerRole,
+  renderTrainerWithGenerator,
+} from "./Trainer.test.common";
 import { describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
 import userEvent, { type UserEvent } from "@testing-library/user-event";
-import { CARDS_PER_DEALT_HAND } from "../game/facts";
 import { SortOrder } from "../ui/SortOrder";
 import { Trainer } from "./Trainer";
-import expectedCribPointsTableData from "../game/expectedCribPointsTable.json";
-import { setTableSync } from "../game/expectedCribPointsTableLoader";
-
-const mathRandom = Math.random;
-const CARD_DRAW_RANDOM_VALUE = 0;
-const DEALER_RANDOM_VALUE = 0.49;
-const PONE_RANDOM_VALUE = 0.5;
-
-const renderTrainerWithGenerator = (generateRandomNumber: () => number) => {
-  setTableSync(
-    expectedCribPointsTableData as unknown as ExpectedCribPointsTable,
-  );
-
-  return render(
-    <Trainer
-      generateRandomNumber={generateRandomNumber}
-      loadGoogleAnalytics={jest.fn()}
-    />,
-  );
-};
-
-const renderTrainer = () => renderTrainerWithGenerator(mathRandom);
-
-const createSequenceGenerator = (values: number[]) =>
-  jest.fn(() => values.shift() ?? 0);
-
-const repeatedRandomValues = (value: number): number[] =>
-  Array.from({ length: CARDS_PER_DEALT_HAND }, () => value);
-
-const createRoleRandomValues = (roleValues: readonly number[]) =>
-  roleValues.flatMap((roleValue) => [
-    ...repeatedRandomValues(CARD_DRAW_RANDOM_VALUE),
-    roleValue,
-  ]);
-
-const calculationsHeaderName = "Hand";
-
-const clickIndices = (
-  getAllByRole: (role: ByRoleMatcher, options?: ByRoleOptions) => HTMLElement[],
-  indices: number[],
-  user: UserEvent,
-) =>
-  indices.reduce(
-    (previousClick, index) =>
-      previousClick.then(() => user.click(getAllByRole("checkbox")[index]!)),
-    Promise.resolve(),
-  );
+/* jscpd:ignore-end */
 
 const toggleCard = async (checkbox: HTMLElement, user: UserEvent) => {
   await user.click(checkbox);
@@ -110,31 +69,6 @@ function getSortInput(container: HTMLElement, sortOrder: SortOrder) {
 const ANALYTICS_CONSENT = "analyticsConsent";
 
 const clearAnalyticsConsent = () => localStorage.removeItem(ANALYTICS_CONSENT);
-
-const isRoleLabelVisible = (roleName: string, roleContext: string) =>
-  Boolean(screen.queryByText(roleName)) &&
-  Boolean(screen.queryByText(roleContext));
-
-const expectDealerRoleVisible = () => {
-  expect(isRoleLabelVisible("Dealer", "your crib")).toBe(true);
-};
-
-const expectPoneRoleVisible = () => {
-  expect(isRoleLabelVisible("Pone", "opponent crib")).toBe(true);
-};
-
-const clickDeal = (user: UserEvent) =>
-  user.click(screen.getByRole("button", { name: "Deal" }));
-
-const renderTrainerShowingDealerRole = () =>
-  renderTrainerWithGenerator(
-    createSequenceGenerator(createRoleRandomValues([DEALER_RANDOM_VALUE])),
-  );
-
-const getHandText = (container: HTMLElement) =>
-  container.querySelector("ul")!.textContent;
-
-const SIX_HEARTS_HAND = "AH,2H,3H,4H,5H,6H";
 
 describe("trainer component", () => {
   it("initially contains a sort in descending order radio input", () => {
@@ -273,241 +207,5 @@ describe("trainer component", () => {
     await toggleCard(firstCheckbox, user);
 
     expect(firstCheckbox).toBeChecked();
-  });
-});
-
-const HAND_PARAM_PATTERN =
-  /^(?:10|[A2-9JQK])[CDHS](?:,(?:10|[A2-9JQK])[CDHS]){5}$/u;
-
-const getSearchParam = (name: string) =>
-  new URLSearchParams(window.location.search).get(name);
-
-const resetUrl = () => {
-  window.history.replaceState(null, "", "/");
-};
-
-const renderHydratedTrainer = () => {
-  setTableSync(
-    expectedCribPointsTableData as unknown as ExpectedCribPointsTable,
-  );
-
-  return render(
-    <Trainer
-      generateRandomNumber={mathRandom}
-      initialCards={parseHand(SIX_HEARTS_HAND)}
-      initialCribRole={CribRole.Pone}
-      initialDiscards={parseHand("AH,2H")}
-      initialSortOrder={SortOrder.DealOrder}
-      loadGoogleAnalytics={jest.fn()}
-    />,
-  );
-};
-
-const popStateTo = (search: string) => {
-  window.history.replaceState(null, "", search);
-  fireEvent.popState(window);
-};
-
-const renderTrainerSpyingOnPush = () => {
-  resetUrl();
-  const user = userEvent.setup();
-  const pushStateSpy = jest.spyOn(window.history, "pushState");
-  return { pushStateSpy, renderResult: renderTrainer(), user };
-};
-
-const expectPushesAndDiscards = (
-  pushStateSpy: unknown,
-  expectedPushes: number,
-  expectedDiscardCount: number,
-) => {
-  expect(pushStateSpy).toHaveBeenCalledTimes(expectedPushes);
-  expect(getSearchParam("discard")?.split(",")).toHaveLength(
-    expectedDiscardCount,
-  );
-};
-
-describe("trainer URL state synchronization", () => {
-  it("writes the full analysis state to the URL on first render", () => {
-    resetUrl();
-    renderTrainer();
-
-    expect(getSearchParam("hand")).toMatch(HAND_PARAM_PATTERN);
-    expect(["dealer", "pone"]).toContain(getSearchParam("role"));
-    expect(getSearchParam("sort")).toBe("descending");
-  });
-
-  it("hydrates the role for a random deal when only a role is supplied", () => {
-    resetUrl();
-    render(
-      <Trainer
-        generateRandomNumber={mathRandom}
-        initialCribRole={CribRole.Pone}
-        loadGoogleAnalytics={jest.fn()}
-      />,
-    );
-
-    expectPoneRoleVisible();
-  });
-
-  it("hydrates role, discards, and sort order from initial props", () => {
-    resetUrl();
-    renderHydratedTrainer();
-
-    expectPoneRoleVisible();
-
-    expect(
-      screen.queryByRole("columnheader", { name: calculationsHeaderName }),
-    ).toBeTruthy();
-    expect(screen.getByLabelText("DealOrder")).toBeChecked();
-  });
-
-  // eslint-disable-next-line jest/prefer-ending-with-an-expect
-  it("pushes history when dealing and restores the prior hand on popstate", async () => {
-    const { pushStateSpy, renderResult, user } = renderTrainerSpyingOnPush();
-    try {
-      const { container } = renderResult;
-      const initialHandText = getHandText(container);
-      const initialSearch = window.location.search;
-
-      await clickDeal(user);
-
-      expect(pushStateSpy).toHaveBeenCalledTimes(1);
-      expect(window.location.search).not.toBe(initialSearch);
-
-      popStateTo(initialSearch);
-
-      expect(getHandText(container)).toBe(initialHandText);
-    } finally {
-      pushStateSpy.mockRestore();
-    }
-  });
-
-  // eslint-disable-next-line jest/prefer-ending-with-an-expect
-  it("pushes stable discard states and replaces transient ones", async () => {
-    const { pushStateSpy, renderResult, user } = renderTrainerSpyingOnPush();
-    const clickCheckbox = (index: number) =>
-      user.click(renderResult.getAllByRole("checkbox")[index]!);
-    try {
-      await clickCheckbox(0);
-
-      expectPushesAndDiscards(pushStateSpy, 1, 1);
-
-      await clickCheckbox(1);
-
-      expectPushesAndDiscards(pushStateSpy, 1, 2);
-
-      await clickCheckbox(0);
-
-      expectPushesAndDiscards(pushStateSpy, 2, 1);
-    } finally {
-      pushStateSpy.mockRestore();
-    }
-  });
-
-  const expectMergedBackTo = async (
-    backSpy: ReturnType<typeof jest.spyOn>,
-    expectedSearch: string,
-  ) => {
-    expect(backSpy).toHaveBeenCalledTimes(1);
-
-    await waitFor(() => {
-      expect(window.location.search).toBe(expectedSearch);
-    });
-  };
-
-  const withBackSpy = async (
-    run: (
-      backSpy: ReturnType<typeof jest.spyOn>,
-      spied: ReturnType<typeof renderTrainerSpyingOnPush>,
-    ) => Promise<void>,
-  ) => {
-    const spied = renderTrainerSpyingOnPush();
-    const backSpy = jest.spyOn(window.history, "back");
-    try {
-      await run(backSpy, spied);
-    } finally {
-      backSpy.mockRestore();
-      spied.pushStateSpy.mockRestore();
-    }
-  };
-
-  // eslint-disable-next-line jest/prefer-ending-with-an-expect
-  it("merges an undone discard toggle instead of duplicating the entry", () =>
-    withBackSpy(async (backSpy, { pushStateSpy, renderResult, user }) => {
-      const initialSearch = window.location.search;
-      const firstCheckbox = renderResult.getAllByRole("checkbox")[0]!;
-
-      await user.click(firstCheckbox);
-
-      expect(getSearchParam("discard")).not.toBeNull();
-
-      await user.click(firstCheckbox);
-
-      expect(pushStateSpy).toHaveBeenCalledTimes(1);
-
-      await expectMergedBackTo(backSpy, initialSearch);
-    }));
-
-  // eslint-disable-next-line jest/prefer-ending-with-an-expect
-  it("merges a wandering mind change back onto the complete discard", () =>
-    withBackSpy(async (backSpy, { renderResult, user }) => {
-      await clickIndices(renderResult.getAllByRole, [0, 1], user);
-      const completeDiscardSearch = window.location.search;
-
-      await clickIndices(renderResult.getAllByRole, [2, 3, 3, 2], user);
-
-      await expectMergedBackTo(backSpy, completeDiscardSearch);
-    }));
-
-  // eslint-disable-next-line jest/prefer-ending-with-an-expect
-  it("pushes history when the sort order changes", async () => {
-    const { pushStateSpy, user } = renderTrainerSpyingOnPush();
-    try {
-      await user.click(screen.getByLabelText("Ascending"));
-
-      expect(pushStateSpy).toHaveBeenCalledTimes(1);
-      expect(getSearchParam("sort")).toBe("ascending");
-    } finally {
-      pushStateSpy.mockRestore();
-    }
-  });
-
-  it("restores sort order from a popstate URL without replacing the hand", () => {
-    resetUrl();
-    renderTrainer();
-    const initialHandParam = getSearchParam("hand");
-
-    popStateTo("?sort=ascending");
-
-    expect(screen.getByLabelText("Ascending")).toBeChecked();
-    expect(getSearchParam("hand")).toBe(initialHandParam);
-  });
-
-  it("restores the role from a popstate URL", () => {
-    resetUrl();
-    renderTrainer();
-
-    popStateTo(`?hand=${SIX_HEARTS_HAND}&role=pone`);
-
-    expectPoneRoleVisible();
-  });
-
-  it("keeps the current role when a popstate URL lacks one", () => {
-    resetUrl();
-    renderTrainerShowingDealerRole();
-
-    popStateTo(`?hand=${SIX_HEARTS_HAND}`);
-
-    expectDealerRoleVisible();
-  });
-
-  it("ignores a popstate URL with an invalid hand", () => {
-    resetUrl();
-    const { container } = renderTrainer();
-    const initialHandText = getHandText(container);
-
-    popStateTo("?hand=XX,YY");
-
-    expect(getHandText(container)).toBe(initialHandText);
   });
 });

--- a/src/ui-react/Trainer.tsx
+++ b/src/ui-react/Trainer.tsx
@@ -10,6 +10,7 @@ import { AnalyticsConsentDialog } from "./AnalyticsConsentDialog";
 import { type Card } from "../game/Card";
 import type { DealtCard } from "../game/DealtCard";
 import { InteractiveHand } from "./InteractiveHand";
+import { ScoredKeepDiscardSortKey } from "../analysis/compareByExpectedScoreDescending";
 import { ScoredPossibleKeepDiscards } from "./ScoredPossibleKeepDiscards";
 import { SortOrder } from "../ui/SortOrder";
 import { dealHand } from "../game/dealHand";
@@ -23,6 +24,7 @@ export interface TrainerProps {
   readonly initialCards?: Card[] | null;
   readonly initialCribRole?: CribRole | null;
   readonly initialDiscards?: Card[] | null;
+  readonly initialScoreSortKey?: ScoredKeepDiscardSortKey | null;
   readonly initialSortOrder?: SortOrder | null;
 }
 
@@ -55,6 +57,7 @@ export function Trainer({
   initialCards = null,
   initialCribRole = null,
   initialDiscards = null,
+  initialScoreSortKey = null,
   initialSortOrder = null,
 }: TrainerProps) {
   const dealHandWithGenerator = useCallback(
@@ -81,6 +84,9 @@ export function Trainer({
   const [sortOrder, setSortOrder] = useState<SortOrder>(
     initialSortOrder ?? SortOrder.Descending,
   );
+  const [scoreSortKey, setScoreSortKey] = useState<ScoredKeepDiscardSortKey>(
+    initialScoreSortKey ?? ScoredKeepDiscardSortKey.ExpectedNetPoints,
+  );
   const storedConsentOnFirstRender = useMemo(() => getStoredConsent(), []);
   const [analyticsConsented, setAnalyticsConsented] = useState<boolean | null>(
     storedConsentOnFirstRender,
@@ -91,6 +97,7 @@ export function Trainer({
     const url = serializeUrlAnalysisState(window.location.search, {
       cribRole,
       dealtCards,
+      scoreSortKey,
       sortOrder,
     });
     if (shouldPushHistory.current) {
@@ -108,7 +115,7 @@ export function Trainer({
       window.history.replaceState(window.history.state, "", url);
     }
     shouldPushHistory.current = false;
-  }, [cribRole, dealtCards, sortOrder]);
+  }, [cribRole, dealtCards, scoreSortKey, sortOrder]);
 
   useEffect(() => {
     const handlePopState = () => {
@@ -124,6 +131,9 @@ export function Trainer({
       }
       if (urlState.sortOrder !== null) {
         setSortOrder(urlState.sortOrder);
+      }
+      if (urlState.scoreSortKey !== null) {
+        setScoreSortKey(urlState.scoreSortKey);
       }
     };
     window.addEventListener("popstate", handlePopState);
@@ -168,6 +178,14 @@ export function Trainer({
     [markHistoryUpdate],
   );
 
+  const changeScoreSortKey = useCallback(
+    (newScoreSortKey: ScoredKeepDiscardSortKey) => {
+      markHistoryUpdate();
+      setScoreSortKey(newScoreSortKey);
+    },
+    [markHistoryUpdate],
+  );
+
   const setConsented = useCallback((value: boolean) => {
     setAnalyticsConsented(value);
     localStorage.setItem(analyticsConsentKey, JSON.stringify(value));
@@ -191,6 +209,8 @@ export function Trainer({
         <ScoredPossibleKeepDiscards
           cribRole={cribRole}
           dealtCards={dealtCards}
+          onScoreSortKeyChange={changeScoreSortKey}
+          scoreSortKey={scoreSortKey}
           sortOrder={sortOrder}
         />
       )}
@@ -207,5 +227,6 @@ Trainer.defaultProps = {
   initialCards: null,
   initialCribRole: null,
   initialDiscards: null,
+  initialScoreSortKey: null,
   initialSortOrder: null,
 };

--- a/src/ui-react/TrainerUrlState.test.tsx
+++ b/src/ui-react/TrainerUrlState.test.tsx
@@ -1,0 +1,315 @@
+import "@testing-library/jest-dom";
+import {
+  SIX_HEARTS_HAND,
+  calculationsHeaderName,
+  clickDeal,
+  clickIndices,
+  expectDealerRoleVisible,
+  expectPoneRoleVisible,
+  getHandText,
+  mathRandom,
+  renderTrainer,
+  renderTrainerShowingDealerRole,
+  setCribTable,
+} from "./Trainer.test.common";
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CribRole } from "../game/expectedCribPoints";
+import { ScoredKeepDiscardSortKey } from "../analysis/compareByExpectedScoreDescending";
+import { SortOrder } from "../ui/SortOrder";
+import { Trainer } from "./Trainer";
+import { parseHand } from "../game/Card";
+import userEvent from "@testing-library/user-event";
+
+const HAND_PARAM_PATTERN =
+  /^(?:10|[A2-9JQK])[CDHS](?:,(?:10|[A2-9JQK])[CDHS]){5}$/u;
+
+const getSearchParam = (name: string) =>
+  new URLSearchParams(window.location.search).get(name);
+
+const resetUrl = () => {
+  window.history.replaceState(null, "", "/");
+};
+
+const renderHydratedTrainer = () => {
+  setCribTable();
+
+  return render(
+    <Trainer
+      generateRandomNumber={mathRandom}
+      initialCards={parseHand(SIX_HEARTS_HAND)}
+      initialCribRole={CribRole.Pone}
+      initialDiscards={parseHand("AH,2H")}
+      initialScoreSortKey={ScoredKeepDiscardSortKey.ExpectedHandPoints}
+      initialSortOrder={SortOrder.DealOrder}
+      loadGoogleAnalytics={jest.fn()}
+    />,
+  );
+};
+
+const findScoreHeader = (name: RegExp) =>
+  screen.findByRole("columnheader", { name });
+
+const popStateTo = (search: string) => {
+  window.history.replaceState(null, "", search);
+  fireEvent.popState(window);
+};
+
+const renderTrainerSpyingOnPush = () => {
+  resetUrl();
+  const user = userEvent.setup();
+  const pushStateSpy = jest.spyOn(window.history, "pushState");
+  return { pushStateSpy, renderResult: renderTrainer(), user };
+};
+
+const expectPushesAndDiscards = (
+  pushStateSpy: unknown,
+  expectedPushes: number,
+  expectedDiscardCount: number,
+) => {
+  expect(pushStateSpy).toHaveBeenCalledTimes(expectedPushes);
+  expect(getSearchParam("discard")?.split(",")).toHaveLength(
+    expectedDiscardCount,
+  );
+};
+
+describe("trainer URL state synchronization", () => {
+  it("writes the full analysis state to the URL on first render", () => {
+    resetUrl();
+    renderTrainer();
+
+    expect(getSearchParam("hand")).toMatch(HAND_PARAM_PATTERN);
+    expect(["dealer", "pone"]).toContain(getSearchParam("role"));
+    expect(getSearchParam("sort")).toBe("descending");
+    expect(getSearchParam("analysis-sort")).toBe("net");
+  });
+
+  it("hydrates the role for a random deal when only a role is supplied", () => {
+    resetUrl();
+    render(
+      <Trainer
+        generateRandomNumber={mathRandom}
+        initialCribRole={CribRole.Pone}
+        loadGoogleAnalytics={jest.fn()}
+      />,
+    );
+
+    expectPoneRoleVisible();
+  });
+
+  it("hydrates role, discards, and sort order from initial props", async () => {
+    resetUrl();
+    renderHydratedTrainer();
+
+    expectPoneRoleVisible();
+
+    await expect(
+      screen.findByRole("columnheader", { name: calculationsHeaderName }),
+    ).resolves.toBeTruthy();
+
+    expect(screen.getByLabelText("DealOrder")).toBeChecked();
+  });
+
+  it("hydrates the analysis sort column from initial props", async () => {
+    resetUrl();
+    renderHydratedTrainer();
+
+    await expect(findScoreHeader(/Hand/u)).resolves.toHaveAttribute(
+      "aria-sort",
+      "descending",
+    );
+
+    expect(getSearchParam("analysis-sort")).toBe("hand");
+  });
+
+  // eslint-disable-next-line jest/prefer-ending-with-an-expect
+  it("pushes history when dealing and restores the prior hand on popstate", async () => {
+    const { pushStateSpy, renderResult, user } = renderTrainerSpyingOnPush();
+    try {
+      const { container } = renderResult;
+      const initialHandText = getHandText(container);
+      const initialSearch = window.location.search;
+
+      await clickDeal(user);
+
+      expect(pushStateSpy).toHaveBeenCalledTimes(1);
+      expect(window.location.search).not.toBe(initialSearch);
+
+      popStateTo(initialSearch);
+
+      expect(getHandText(container)).toBe(initialHandText);
+    } finally {
+      pushStateSpy.mockRestore();
+    }
+  });
+
+  // eslint-disable-next-line jest/prefer-ending-with-an-expect
+  it("pushes stable discard states and replaces transient ones", async () => {
+    const { pushStateSpy, renderResult, user } = renderTrainerSpyingOnPush();
+    const clickCheckbox = (index: number) =>
+      user.click(renderResult.getAllByRole("checkbox")[index]!);
+    try {
+      await clickCheckbox(0);
+
+      expectPushesAndDiscards(pushStateSpy, 1, 1);
+
+      await clickCheckbox(1);
+
+      expectPushesAndDiscards(pushStateSpy, 1, 2);
+
+      await clickCheckbox(0);
+
+      expectPushesAndDiscards(pushStateSpy, 2, 1);
+    } finally {
+      pushStateSpy.mockRestore();
+    }
+  });
+
+  const expectMergedBackTo = async (
+    backSpy: ReturnType<typeof jest.spyOn>,
+    expectedSearch: string,
+  ) => {
+    expect(backSpy).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(window.location.search).toBe(expectedSearch);
+    });
+  };
+
+  const withBackSpy = async (
+    run: (
+      backSpy: ReturnType<typeof jest.spyOn>,
+      spied: ReturnType<typeof renderTrainerSpyingOnPush>,
+    ) => Promise<void>,
+  ) => {
+    const spied = renderTrainerSpyingOnPush();
+    const backSpy = jest.spyOn(window.history, "back");
+    try {
+      await run(backSpy, spied);
+    } finally {
+      backSpy.mockRestore();
+      spied.pushStateSpy.mockRestore();
+    }
+  };
+
+  // eslint-disable-next-line jest/prefer-ending-with-an-expect
+  it("merges an undone discard toggle instead of duplicating the entry", () =>
+    withBackSpy(async (backSpy, { pushStateSpy, renderResult, user }) => {
+      const initialSearch = window.location.search;
+      const firstCheckbox = renderResult.getAllByRole("checkbox")[0]!;
+
+      await user.click(firstCheckbox);
+
+      expect(getSearchParam("discard")).not.toBeNull();
+
+      await user.click(firstCheckbox);
+
+      expect(pushStateSpy).toHaveBeenCalledTimes(1);
+
+      await expectMergedBackTo(backSpy, initialSearch);
+    }));
+
+  // eslint-disable-next-line jest/prefer-ending-with-an-expect
+  it("merges a wandering mind change back onto the complete discard", () =>
+    withBackSpy(async (backSpy, { renderResult, user }) => {
+      await clickIndices(renderResult.getAllByRole, [0, 1], user);
+      const completeDiscardSearch = window.location.search;
+
+      await clickIndices(renderResult.getAllByRole, [2, 3, 3, 2], user);
+
+      await expectMergedBackTo(backSpy, completeDiscardSearch);
+    }));
+
+  // eslint-disable-next-line jest/prefer-ending-with-an-expect
+  it("pushes history when the sort order changes", async () => {
+    const { pushStateSpy, user } = renderTrainerSpyingOnPush();
+    try {
+      await user.click(screen.getByLabelText("Ascending"));
+
+      expect(pushStateSpy).toHaveBeenCalledTimes(1);
+      expect(getSearchParam("sort")).toBe("ascending");
+    } finally {
+      pushStateSpy.mockRestore();
+    }
+  });
+
+  const renderDiscardedTrainerSpyingOnPush = async () => {
+    const spied = renderTrainerSpyingOnPush();
+    await clickIndices(spied.renderResult.getAllByRole, [0, 1], spied.user);
+    return spied;
+  };
+
+  // eslint-disable-next-line jest/prefer-ending-with-an-expect
+  it("pushes history when the analysis sort column changes", async () => {
+    const { pushStateSpy, user } = await renderDiscardedTrainerSpyingOnPush();
+    try {
+      const cribHeaderButton = await screen.findByRole("button", {
+        name: /^Crib:/u,
+      });
+
+      await user.click(cribHeaderButton);
+
+      // The two toggles yield one push (the transient state is replaced).
+      const pushesAfterCompleteDiscardAndSort = 2;
+
+      expect(pushStateSpy).toHaveBeenCalledTimes(
+        pushesAfterCompleteDiscardAndSort,
+      );
+      expect(getSearchParam("analysis-sort")).toBe("crib");
+    } finally {
+      pushStateSpy.mockRestore();
+    }
+  });
+
+  it("restores the analysis sort column from a popstate URL", async () => {
+    resetUrl();
+    renderHydratedTrainer();
+    await screen.findByRole("button", { name: /^Net:/u });
+
+    popStateTo("?analysis-sort=net");
+
+    await expect(findScoreHeader(/Net/u)).resolves.toHaveAttribute(
+      "aria-sort",
+      "descending",
+    );
+  });
+
+  it("restores sort order from a popstate URL without replacing the hand", () => {
+    resetUrl();
+    renderTrainer();
+    const initialHandParam = getSearchParam("hand");
+
+    popStateTo("?sort=ascending");
+
+    expect(screen.getByLabelText("Ascending")).toBeChecked();
+    expect(getSearchParam("hand")).toBe(initialHandParam);
+  });
+
+  it("restores the role from a popstate URL", () => {
+    resetUrl();
+    renderTrainer();
+
+    popStateTo(`?hand=${SIX_HEARTS_HAND}&role=pone`);
+
+    expectPoneRoleVisible();
+  });
+
+  it("keeps the current role when a popstate URL lacks one", () => {
+    resetUrl();
+    renderTrainerShowingDealerRole();
+
+    popStateTo(`?hand=${SIX_HEARTS_HAND}`);
+
+    expectDealerRoleVisible();
+  });
+
+  it("ignores a popstate URL with an invalid hand", () => {
+    resetUrl();
+    const { container } = renderTrainer();
+    const initialHandText = getHandText(container);
+
+    popStateTo("?hand=XX,YY");
+
+    expect(getHandText(container)).toBe(initialHandText);
+  });
+});

--- a/src/ui/getInitialProps.test.ts
+++ b/src/ui/getInitialProps.test.ts
@@ -1,7 +1,10 @@
+/* jscpd:ignore-start */
 import { describe, expect, it } from "@jest/globals";
 import { CribRole } from "../game/expectedCribPoints";
+import { ScoredKeepDiscardSortKey } from "../analysis/compareByExpectedScoreDescending";
 import { SortOrder } from "./SortOrder";
 import { getInitialProps } from "./getInitialProps";
+/* jscpd:ignore-end */
 
 describe("getInitialProps", () => {
   it("returns null initialCards when no hand param is present", () => {
@@ -44,21 +47,25 @@ describe("getInitialProps", () => {
     expect(props.seed).toBeNull();
   });
 
-  it("returns parsed role, discards, and sort order when present", () => {
+  it("returns parsed role, discards, and sort orders when present", () => {
     const props = getInitialProps(
-      "?hand=AH,2H,3H,4H,5H,6H&role=dealer&discard=AH&sort=deal-order",
+      "?hand=AH,2H,3H,4H,5H,6H&role=dealer&discard=AH&sort=deal-order&analysis-sort=crib",
     );
 
     expect(props.initialCribRole).toBe(CribRole.Dealer);
     expect(props.initialDiscards?.[0]?.rankLabel).toBe("A");
+    expect(props.initialScoreSortKey).toBe(
+      ScoredKeepDiscardSortKey.ExpectedCribPoints,
+    );
     expect(props.initialSortOrder).toBe(SortOrder.DealOrder);
   });
 
-  it("returns null role, discards, and sort order when absent", () => {
+  it("returns null role, discards, and sort orders when absent", () => {
     const props = getInitialProps("?hand=AH,2H,3H,4H,5H,6H");
 
     expect(props.initialCribRole).toBeNull();
     expect(props.initialDiscards).toBeNull();
+    expect(props.initialScoreSortKey).toBeNull();
     expect(props.initialSortOrder).toBeNull();
   });
 });

--- a/src/ui/getInitialProps.ts
+++ b/src/ui/getInitialProps.ts
@@ -1,12 +1,13 @@
 import { SEED_PARAM, parseUrlAnalysisState } from "./urlAnalysisState";
 
 export const getInitialProps = (search: string) => {
-  const { cards, cribRole, discards, sortOrder } =
+  const { cards, cribRole, discards, scoreSortKey, sortOrder } =
     parseUrlAnalysisState(search);
   return {
     initialCards: cards,
     initialCribRole: cribRole,
     initialDiscards: discards,
+    initialScoreSortKey: scoreSortKey,
     initialSortOrder: sortOrder,
     seed: new URLSearchParams(search).get(SEED_PARAM),
   };

--- a/src/ui/urlAnalysisState.test.ts
+++ b/src/ui/urlAnalysisState.test.ts
@@ -6,6 +6,7 @@ import {
 import { describe, expect, it } from "@jest/globals";
 import { CARDS_PER_DEALT_HAND } from "../game/facts";
 import { CribRole } from "../game/expectedCribPoints";
+import { ScoredKeepDiscardSortKey } from "../analysis/compareByExpectedScoreDescending";
 import { SortOrder } from "./SortOrder";
 import { parseHand } from "../game/Card";
 import { toDealtCards } from "../game/toDealtCards";
@@ -29,10 +30,14 @@ const expectHydratedPoneState = (
 describe("parseUrlAnalysisState", () => {
   it("parses a full valid state", () => {
     const state = parseUrlAnalysisState(
-      `?hand=${VALID_HAND}&role=pone&discard=6S,5H&sort=ascending`,
+      `?hand=${VALID_HAND}&role=pone&discard=6S,5H&sort=ascending&analysis-sort=play`,
     );
 
     expectHydratedPoneState(state, ["6", "5"], SortOrder.Ascending);
+
+    expect(state.scoreSortKey).toBe(
+      ScoredKeepDiscardSortKey.ExpectedPlayPoints,
+    );
   });
 
   it("returns all nulls for an empty search string", () => {
@@ -40,6 +45,7 @@ describe("parseUrlAnalysisState", () => {
       cards: null,
       cribRole: null,
       discards: null,
+      scoreSortKey: null,
       sortOrder: null,
     });
   });
@@ -96,25 +102,63 @@ describe("parseUrlAnalysisState", () => {
   it("returns a null sort order for an unknown sort value", () => {
     expect(parseUrlAnalysisState("?sort=random").sortOrder).toBeNull();
   });
+
+  it.each([
+    ["hand", ScoredKeepDiscardSortKey.ExpectedHandPoints],
+    ["crib", ScoredKeepDiscardSortKey.ExpectedCribPoints],
+    ["play", ScoredKeepDiscardSortKey.ExpectedPlayPoints],
+    ["NET", ScoredKeepDiscardSortKey.ExpectedNetPoints],
+  ])(
+    "parses analysis sort %p case-insensitively",
+    (analysisSort, expectedScoreSortKey) => {
+      expect(
+        parseUrlAnalysisState(`?analysis-sort=${analysisSort}`).scoreSortKey,
+      ).toBe(expectedScoreSortKey);
+    },
+  );
+
+  it("returns a null score sort key for an unknown analysis sort value", () => {
+    expect(
+      parseUrlAnalysisState("?analysis-sort=starter").scoreSortKey,
+    ).toBeNull();
+  });
 });
 
 const dealerStateDiscardingSixFive = (sortOrder: SortOrder) => ({
   cribRole: CribRole.Dealer,
   dealtCards: toDealtCards(parseHand(VALID_HAND), parseHand("6S,5H")),
+  scoreSortKey: ScoredKeepDiscardSortKey.ExpectedNetPoints,
   sortOrder,
 });
 
 describe("serializeUrlAnalysisState", () => {
-  it("serializes hand, role, discards, and sort while preserving other params", () => {
+  it("serializes hand, role, discards, and sorts while preserving other params", () => {
     const url = serializeUrlAnalysisState(
       "?seed=123",
       dealerStateDiscardingSixFive(SortOrder.DealOrder),
     );
 
     expect(url).toBe(
-      `?seed=123&hand=${VALID_HAND}&role=dealer&discard=6S,5H&sort=deal-order`,
+      `?seed=123&hand=${VALID_HAND}&role=dealer&discard=6S,5H&sort=deal-order&analysis-sort=net`,
     );
   });
+
+  it.each([
+    [ScoredKeepDiscardSortKey.ExpectedHandPoints, "hand"],
+    [ScoredKeepDiscardSortKey.ExpectedCribPoints, "crib"],
+    [ScoredKeepDiscardSortKey.ExpectedPlayPoints, "play"],
+    [ScoredKeepDiscardSortKey.ExpectedNetPoints, "net"],
+  ])(
+    "serializes score sort key %p as analysis sort %p",
+    (scoreSortKey, expectedAnalysisSort) => {
+      const url = serializeUrlAnalysisState("", {
+        ...dealerStateDiscardingSixFive(SortOrder.Descending),
+        scoreSortKey,
+      });
+
+      expect(url).toContain(`analysis-sort=${expectedAnalysisSort}`);
+    },
+  );
 
   it("keeps encoded commas in unrelated params while decoding card lists", () => {
     const url = serializeUrlAnalysisState(
@@ -131,33 +175,41 @@ describe("serializeUrlAnalysisState", () => {
     const url = serializeUrlAnalysisState("?discard=6S", {
       cribRole: CribRole.Pone,
       dealtCards: toDealtCards(parseHand(VALID_HAND), null),
+      scoreSortKey: ScoredKeepDiscardSortKey.ExpectedNetPoints,
       sortOrder: SortOrder.Descending,
     });
 
-    expect(url).toBe(`?hand=${VALID_HAND}&role=pone&sort=descending`);
+    expect(url).toBe(
+      `?hand=${VALID_HAND}&role=pone&sort=descending&analysis-sort=net`,
+    );
   });
 
   it("writes cards in deal order regardless of array order", () => {
     const url = serializeUrlAnalysisState("", {
       cribRole: CribRole.Dealer,
       dealtCards: toDealtCards(parseHand(VALID_HAND), null).reverse(),
+      scoreSortKey: ScoredKeepDiscardSortKey.ExpectedNetPoints,
       sortOrder: SortOrder.Ascending,
     });
 
-    expect(url).toBe(`?hand=${VALID_HAND}&role=dealer&sort=ascending`);
+    expect(url).toBe(
+      `?hand=${VALID_HAND}&role=dealer&sort=ascending&analysis-sort=net`,
+    );
   });
 
   it("round-trips through parseUrlAnalysisState", () => {
     const url = serializeUrlAnalysisState("", {
       cribRole: CribRole.Pone,
       dealtCards: toDealtCards(parseHand(VALID_HAND), parseHand("KH")),
+      scoreSortKey: ScoredKeepDiscardSortKey.ExpectedCribPoints,
       sortOrder: SortOrder.Ascending,
     });
+    const state = parseUrlAnalysisState(url);
 
-    expectHydratedPoneState(
-      parseUrlAnalysisState(url),
-      ["K"],
-      SortOrder.Ascending,
+    expectHydratedPoneState(state, ["K"], SortOrder.Ascending);
+
+    expect(state.scoreSortKey).toBe(
+      ScoredKeepDiscardSortKey.ExpectedCribPoints,
     );
   });
 });

--- a/src/ui/urlAnalysisState.ts
+++ b/src/ui/urlAnalysisState.ts
@@ -7,18 +7,21 @@ import {
 } from "../game/Card";
 import { CribRole } from "../game/expectedCribPoints";
 import type { DealtCard } from "../game/DealtCard";
+import { ScoredKeepDiscardSortKey } from "../analysis/compareByExpectedScoreDescending";
 import { SortOrder } from "./SortOrder";
 
 export const HAND_PARAM = "hand";
 export const ROLE_PARAM = "role";
 export const DISCARD_PARAM = "discard";
 export const SORT_PARAM = "sort";
+export const ANALYSIS_SORT_PARAM = "analysis-sort";
 export const SEED_PARAM = "seed";
 
 export interface UrlAnalysisState {
   readonly cards: Card[] | null;
   readonly cribRole: CribRole | null;
   readonly discards: Card[] | null;
+  readonly scoreSortKey: ScoredKeepDiscardSortKey | null;
   readonly sortOrder: SortOrder | null;
 }
 
@@ -87,6 +90,38 @@ const sortUrlValue = (sortOrder: SortOrder): string => {
   }
 };
 
+const parseAnalysisSortParam = (
+  value: string | null,
+): ScoredKeepDiscardSortKey | null => {
+  switch (value?.toLowerCase()) {
+    case "hand":
+      return ScoredKeepDiscardSortKey.ExpectedHandPoints;
+    case "crib":
+      return ScoredKeepDiscardSortKey.ExpectedCribPoints;
+    case "play":
+      return ScoredKeepDiscardSortKey.ExpectedPlayPoints;
+    case "net":
+      return ScoredKeepDiscardSortKey.ExpectedNetPoints;
+    default:
+      return null;
+  }
+};
+
+const analysisSortUrlValue = (
+  scoreSortKey: ScoredKeepDiscardSortKey,
+): string => {
+  switch (scoreSortKey) {
+    case ScoredKeepDiscardSortKey.ExpectedHandPoints:
+      return "hand";
+    case ScoredKeepDiscardSortKey.ExpectedCribPoints:
+      return "crib";
+    case ScoredKeepDiscardSortKey.ExpectedPlayPoints:
+      return "play";
+    default:
+      return "net";
+  }
+};
+
 export const parseUrlAnalysisState = (search: string): UrlAnalysisState => {
   const params = new URLSearchParams(search);
   const cards = parseHandParam(params.get(HAND_PARAM));
@@ -94,6 +129,7 @@ export const parseUrlAnalysisState = (search: string): UrlAnalysisState => {
     cards,
     cribRole: parseRoleParam(params.get(ROLE_PARAM)),
     discards: parseDiscardParam(params.get(DISCARD_PARAM), cards),
+    scoreSortKey: parseAnalysisSortParam(params.get(ANALYSIS_SORT_PARAM)),
     sortOrder: parseSortParam(params.get(SORT_PARAM)),
   };
 };
@@ -101,6 +137,7 @@ export const parseUrlAnalysisState = (search: string): UrlAnalysisState => {
 export interface SerializableAnalysisState {
   readonly cribRole: CribRole;
   readonly dealtCards: readonly DealtCard[];
+  readonly scoreSortKey: ScoredKeepDiscardSortKey;
   readonly sortOrder: SortOrder;
 }
 
@@ -120,7 +157,7 @@ const decodeCardListCommas = (query: string): string =>
 
 export const serializeUrlAnalysisState = (
   search: string,
-  { cribRole, dealtCards, sortOrder }: SerializableAnalysisState,
+  { cribRole, dealtCards, scoreSortKey, sortOrder }: SerializableAnalysisState,
 ): string => {
   const params = new URLSearchParams(search);
   const cardsInDealOrder = [...dealtCards].sort(
@@ -135,5 +172,6 @@ export const serializeUrlAnalysisState = (
     params.delete(DISCARD_PARAM);
   }
   params.set(SORT_PARAM, sortUrlValue(sortOrder));
+  params.set(ANALYSIS_SORT_PARAM, analysisSortUrlValue(scoreSortKey));
   return `?${decodeCardListCommas(params.toString())}`;
 };

--- a/tests-e2e/index.spec.ts
+++ b/tests-e2e/index.spec.ts
@@ -76,11 +76,11 @@ test("pre-cut hand points show after select of two discards", async ({
 
 const ascendingSuitedDiscardRowText = "9♣10♦Q♠K♥(5♠6♠)";
 
-test("deep link hydrates hand, role, discards, and sort order", async ({
+test("deep link hydrates hand, role, discards, sort order, and analysis sort", async ({
   page,
 }) => {
   await page.goto(
-    `/${suitedAnalysisQuery}&role=pone&discard=6S,5S&sort=ascending`,
+    `/${suitedAnalysisQuery}&role=pone&discard=6S,5S&sort=ascending&analysis-sort=hand`,
   );
 
   await expect(page.getByText("Pone", exactTextMatch)).toBeVisible();
@@ -90,6 +90,9 @@ test("deep link hydrates hand, role, discards, and sort order", async ({
       .filter({ hasText: ascendingSuitedDiscardRowText }),
   ).toBeVisible();
   await expect(page.getByRole("radio", { name: "Ascending" })).toBeChecked();
+  await expect(
+    page.getByRole("columnheader", { name: /Hand/u }),
+  ).toHaveAttribute("aria-sort", "descending");
 });
 
 const constantHandText = "K♥Q♠10♦9♣6♠5♥";

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,10 +28,10 @@ export default {
       ],
       reportsDirectory: path.join(dirname, "coverage"),
       thresholds: {
-        branches: 82.4,
-        functions: 94.46,
-        lines: 91.94,
-        statements: 92.13,
+        branches: 81.39,
+        functions: 94.19,
+        lines: 91.29,
+        statements: 91.51,
       },
     },
     projects: [


### PR DESCRIPTION
Follow-up to #646 for #595 (now closed): the discard-analysis table's sort column (Hand/Crib/Play/Net) was component-local state, so it was lost on share/reload/Back. This PR captures it in a new `analysis-sort` URL param. Rebased onto `main` after both #646 and #649 merged.

## What changed

- New `analysis-sort` param (`hand` | `crib` | `play` | `net`) in `src/ui/urlAnalysisState.ts`, following the existing strict-but-soft-failing parse and always-serialize patterns; additive, so all previously shared links keep working.
- `scoreSortKey` state lifted from `ScoredPossibleKeepDiscards` into `Trainer`; the table is now a controlled component (`scoreSortKey` + `onScoreSortKeyChange` props). Header clicks route through `markHistoryUpdate()` — the table only renders in a stable (complete-discard) state, so each sort change pushes — the popstate handler restores the column, and the chosen column now survives the table unmounting while the user re-discards (previously it silently reset to Net).
- Hydration via `getInitialProps`/`index.tsx` through a new `initialScoreSortKey` prop.
- **Test-file split** (rebase consequence): the union of this PR's and #649's tests pushed `Trainer.test.tsx` past the 520-line `max-lines` cap. Shared helpers moved to `Trainer.test.common.tsx` (coverage-excluded in `jest.config.json`, mirroring the `handToSortedString.test.common.ts` precedent; ESLint test-file globs extended to `*.test.common.ts*`), and the URL-state suite moved to `TrainerUrlState.test.tsx`. The split exposed a latent test-order dependency — the hydration test had been relying on earlier tests in the same file to warm the async play-table cache; it now awaits the table load explicitly.

## Review guide (suggested file order)

1. `src/ui/urlAnalysisState.ts` — the param contract; the two new switches mirror `parseSortParam`/`sortUrlValue`.
2. `src/ui-react/Trainer.tsx` — state lift, `markHistoryUpdate` on change, popstate restore; note the #649 merge logic composes untouched (a header click always pushes, so the convergence path is unaffected by this feature).
3. `src/ui-react/ScoredPossibleKeepDiscards.tsx` — local `useState` removed, controlled props added.
4. `src/ui-react/Trainer.test.common.tsx` / `TrainerUrlState.test.tsx` / `Trainer.test.tsx` — the split; the moved tests are verbatim except the hydration test's new `await`.
5. Remaining tests/stories/e2e, then docs (`AGENTS.md`, `.github/copilot-instructions.md`, `jest.config.json`, `eslint.config.mjs`).

Design decisions worth challenging:

- **Always-serialize**: `analysis-sort=net` is written even at its default, matching how `sort=descending` is always written.
- **Fully controlled component** rather than initial-value + onChange: needed so Back/Forward can restore the column from outside; direct consumers (stories, tests) must now pass both props.
- **URL values are column words** (`hand`/`crib`/`play`/`net`) rather than internal sort-key strings, keeping the enum renameable without breaking shared links.
- **Expand/collapse of per-row breakdowns is intentionally not persisted** (discussed post-#646): too much URL surface for view-level state, and it would force a push-vs-replace exception to the stable-state history rule.

Honest flags:

- Storybook coverage thresholds re-locked to exact totals: branches 82.4 → 81.39, functions 94.46 → 94.19, lines 91.94 → 91.29, statements 92.13 → 91.51 (the new parse/popstate branches are Jest-covered — all touched files stay at 100% there — but not story-reachable).
- Branch commit is unsigned (headless session cannot drive pinentry); the GitHub squash merge will sign what lands on `main`.
- Copilot's earlier zero-findings review predates the #649 rebase and the test split; a fresh review has been requested on the final diff.

## Testing done (post-rebase, against main with #649)

- Jest: 464/464, 100% global coverage.
- Lint gauntlet green; jscpd 0%; cspell clean on all 17 changed files (`--no-gitignore` run; the in-worktree npm script false-fails because the worktree lives under a gitignored path).
- Storybook vitest: 86/86 including the new `SortAnalysisByPlayPoints` story and the reworked `SortedByHandPoints`.
- Playwright: 50/50 across all five browser projects, including the extended deep-link test asserting `aria-sort` and #649's mind-change history test running against this branch.
- Docker pre-commit hook (build + in-container Jest/lint/e2e) passed on the final tree.

## Manual testing plan

1. `npm run start`, deal, discard two cards; click the **Crib** header — URL gains `analysis-sort=crib`.
2. Press **Back** — the sort column returns to **Net** (aria-sort on the Net header) and the URL reverts.
3. Copy the URL after clicking **Hand**, open it in a new tab — the table appears sorted by Hand.
4. Toggle a discard off and back on — the chosen column is preserved across the table disappearing/reappearing, and (per #649) the URL returns to its prior value without adding a blank history entry.
5. Try `?analysis-sort=starter` (invalid) — app loads normally with the default Net sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)