### PR TITLE
docs: require learnings capture in every PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,11 @@
 ## Contribution notes
 
 - Add/adjust tests alongside code changes.
+- Capture each session's durable, non-obvious learnings — new invariants,
+  debugging techniques, tooling or review-workflow gotchas — in `AGENTS.md`
+  (or the matching `skills/*/SKILL.md` when the learning is task-shaped) as
+  part of the same PR as the code change, not as a follow-up. When a change
+  set produced no such learnings, say so in the PR description.
 - In-code comments must document only the non-obvious _why_ — invariants,
   the rationale for a surprising call, consequences/trade-offs, or guards
   against "simplifying" an argument that looks redundant. Never restate the


### PR DESCRIPTION
Claude Code (Fable 5, medium effort) agent:

## Summary

Adds a Contribution notes bullet requiring every coding session — Claude, Codex, or any other agent — to capture its durable, non-obvious learnings (new invariants, debugging techniques, tooling or review-workflow gotchas) in AGENTS.md or the matching skills/*/SKILL.md within the same PR as the code change, and to state explicitly in the PR description when a change set produced no such learnings.

Requested by Mark so both Claude and Codex keep the repository contract improving instead of relying on per-session memory. A matching change is being proposed in simulate-cribbage-games.

## Testing plan

Doc-only: markdownlint, cspell, and prettier pass on AGENTS.md.

No learnings beyond the policy itself arose from this doc-only change.