### PR TITLE
docs: capture interaction UI learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,29 @@
   `page.addStyleTag({ content: "html { font-size: 28px; }" })` after `goto`
   and assert layout bounds; emulated devices at default font scale will not
   show these overflows.
+- Add a visual regression viewport with the exact width, height, and resulting
+  aspect ratio that exposed a layout bug. Portrait and phone-landscape
+  baselines alone do not cover near-square windows or other breakpoint edges.
+
+## Interaction design and visual-state debugging
+
+- Name an action for its immediate effect, not a later workflow outcome. For
+  example, a dialog button that commits six chosen cards but leaves the user
+  to select two discards is "Use hand", not "Analyze".
+- Preserve native form semantics when styling controls. Keep radio inputs in
+  the accessibility tree and style their adjacent labels as buttons; retain
+  the native role, name, checked state, and `:focus-visible` behavior.
+- When a deselected control still looks selected, inspect state selectors
+  independently before changing React logic: check `aria-pressed`,
+  `:focus-visible`, and `:hover`. An unselected hover style that resembles the
+  selected style can make correct application state appear stale.
+- A declared color transition is insufficient if its endpoints are visually
+  indistinguishable. Review both entering and leaving hover in the rendered UI
+  and use a target color with a perceptible contrast change consistent with
+  peer controls.
+- On short screens, place a modal's primary and secondary actions before a
+  long scrolling picker and keep the action row sticky. Users should see how
+  to complete the dialog without first discovering an off-screen footer.
 
 ## Responsive layout invariants
 


### PR DESCRIPTION
Codex GPT-5.6 Sol (High effort) agent:

## Summary

- require visual-regression coverage at the exact geometry that exposed a layout bug
- document action labels that describe their immediate effect
- preserve native form semantics while styling radio controls as buttons
- distinguish application state from hover and focus visual states during debugging
- require perceptible transitions and discoverable sticky modal actions on short screens

## Why

The iterative UI review of manual hand entry in #653 produced reusable interaction-design and visual-debugging lessons. PR #657 already captured the broader responsive-layout invariants, so this PR adds only the remaining guidance without duplicating it.

## Testing

- `npm run lint:markdownlint`
- `npm run lint:prettier`
- `npm run lint:cspell`
- `npm run docker:build-and-test-all` (commit hook; 117 Playwright tests passed)

## Learnings

This documentation-only PR is itself the requested durable learnings capture; it produced no additional non-obvious repository guidance beyond the additions in `AGENTS.md`.
