### PR TITLE
Deploy PRs to a preview site

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,7 @@
     "cutscolumn",
     "camelcase",
     "discardable",
+    "elif",
     "espree",
     "fieldset",
     "figcaption",
@@ -38,6 +39,7 @@
     "subshells",
     "TJQK",
     "tsbuildinfo",
-    "Vite"
+    "Vite",
+    "worktree"
   ]
 }

--- a/.github/actions/publish-pages-content/action.yml
+++ b/.github/actions/publish-pages-content/action.yml
@@ -1,0 +1,70 @@
+name: Publish Pages content
+description: >-
+  Applies a scoped mutation (production replace, PR preview publish, or PR
+  preview removal) to the persistent pages-content state branch, then
+  deploys the resulting merged tree to GitHub Pages. The pages-content
+  branch is a git-based cache between ephemeral runners, not the Pages
+  publishing source itself; it stores the production site root plus a
+  pr/<number>/ directory per currently-open preview. A single commit is
+  kept and amended in place on every publish so the branch's history and
+  storage never grow.
+inputs:
+  merge-args:
+    description: >-
+      Arguments passed to scripts/pagesContentMerge.mjs, e.g. "prod dist",
+      "pr 123 dist", or "remove 123". The checkout directory is appended
+      automatically.
+    required: true
+  commit-message:
+    description: Commit message recorded on the pages-content state branch.
+    required: true
+outputs:
+  page_url:
+    description: The root URL of the deployed GitHub Pages site.
+    value: ${{ steps.deploy.outputs.page_url }}
+runs:
+  using: composite
+  steps:
+    - name: Check out persistent Pages content store
+      shell: bash
+      run: |
+        git fetch origin pages-content || true
+        if git show-ref --verify --quiet refs/remotes/origin/pages-content; then
+          git worktree add pages-content-checkout pages-content
+        else
+          git worktree add --detach pages-content-checkout
+          git -C pages-content-checkout checkout --orphan pages-content
+          git -C pages-content-checkout rm -rf --quiet .
+        fi
+
+    - name: Apply content mutation
+      shell: bash
+      run: node scripts/pagesContentMerge.mjs ${{ inputs.merge-args }} pages-content-checkout
+
+    - name: Commit and push the content store
+      shell: bash
+      working-directory: pages-content-checkout
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add --all
+        if git diff --cached --quiet && git rev-parse HEAD > /dev/null 2>&1; then
+          echo "No content changes to publish."
+        elif git rev-parse HEAD > /dev/null 2>&1; then
+          git commit --quiet --amend --message "${{ inputs.commit-message }}"
+          git push --force origin HEAD:pages-content
+        else
+          git commit --quiet --message "${{ inputs.commit-message }}"
+          git push --force origin HEAD:pages-content
+        fi
+
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: pages-content-checkout/
+
+    - id: deploy
+      name: Deploy GitHub Pages site
+      uses: actions/deploy-pages@v4
+      with:
+        token: ${{ github.token }}

--- a/.github/actions/publish-pages-content/action.yml
+++ b/.github/actions/publish-pages-content/action.yml
@@ -41,6 +41,10 @@ runs:
       shell: bash
       run: node scripts/pagesContentMerge.mjs ${{ inputs.merge-args }} pages-content-checkout
 
+    - name: Refuse to deploy a tree that would take production down
+      shell: bash
+      run: node scripts/pagesContentMerge.mjs assert-deployable pages-content-checkout
+
     - name: Commit and push the content store
       shell: bash
       working-directory: pages-content-checkout

--- a/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
@@ -144,7 +144,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BRANCH="${GITHUB_REF#refs/heads/}"
-          PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number,author,isCrossRepository --jq '.[0] // empty')
+          # The --head filter prefix-matches branch names (github/cli#10816),
+          # so select on exact headRefName equality to never publish this
+          # branch's build to a similarly named branch's PR path.
+          PR_LIST=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number,author,isCrossRepository,headRefName)
+          PR_JSON=$(jq --arg branch "$BRANCH" '[.[] | select(.headRefName == $branch)][0] // empty' <<< "$PR_LIST")
           if [ -z "$PR_JSON" ]; then
             echo "No open pull request found for branch $BRANCH; skipping preview deploy."
             echo "eligible=false" >> "$GITHUB_OUTPUT"
@@ -178,6 +182,7 @@ jobs:
       contents: write # to push the pages-content state branch
       pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
+      pull-requests: read # to recheck the PR is still open before publishing
 
     # A separate, unprotected environment from github-pages: that
     # environment's branch policy permits deployments only from main.
@@ -204,7 +209,24 @@ jobs:
           PAGES_BASE_PATH: /cribbage-trainer/pr/${{ needs.resolve-preview-pr.outputs.number }}
           VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ vars.VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID }}
 
+      # The eligibility check ran before the ~6-minute build-and-test gate;
+      # if the PR closed in that window, publishing would recreate a preview
+      # that the cleanup workflow already removed (or is about to remove).
+      - id: recheck
+        name: Confirm the pull request is still open
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          STATE=$(gh pr view "${{ needs.resolve-preview-pr.outputs.number }}" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')
+          if [ "$STATE" = "OPEN" ]; then
+            echo "open=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pull request #${{ needs.resolve-preview-pr.outputs.number }} is $STATE; skipping preview publish."
+            echo "open=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish preview content and deploy
+        if: steps.recheck.outputs.open == 'true'
         uses: ./.github/actions/publish-pages-content
         with:
           merge-args: pr ${{ needs.resolve-preview-pr.outputs.number }} dist

--- a/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
@@ -15,6 +15,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Run pages-content merge logic tests
+        run: npm run test:pages-content-merge
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,15 +60,24 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
 
+    # Shared across every job that publishes to Pages so a production
+    # deploy and a PR preview deploy can never race on the pages-content
+    # state branch (see .github/actions/publish-pages-content).
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
+
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    # and to push the pages-content state branch.
     permissions:
+      contents: write # to push the pages-content state branch
       pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
 
     # Deploy to the github-pages environment
     environment:
       name: github-pages
-      url: ${{ steps.deploy-to-github-pages.outputs.page_url }}
+      url: ${{ steps.publish.outputs.page_url }}
 
     steps:
       - name: Checkout repository
@@ -104,13 +121,91 @@ jobs:
         if: steps.cache-dist.outputs.cache-hit != 'true'
         run: npm run storybook:build
 
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - id: publish
+        name: Publish production content and deploy
+        uses: ./.github/actions/publish-pages-content
         with:
-          path: dist/
+          merge-args: prod dist
+          commit-message: Publish production content
 
-      - id: deploy-to-github-pages
-        name: Deploy GitHub Pages site
-        uses: actions/deploy-pages@v4
+  resolve-preview-pr:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    permissions:
+      pull-requests: read
+    outputs:
+      eligible: ${{ steps.resolve.outputs.eligible }}
+      number: ${{ steps.resolve.outputs.number }}
+      url: ${{ steps.resolve.outputs.url }}
+    steps:
+      - id: resolve
+        name: Resolve the open, same-repository, non-Dependabot PR for this branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number,author,isCrossRepository --jq '.[0] // empty')
+          if [ -z "$PR_JSON" ]; then
+            echo "No open pull request found for branch $BRANCH; skipping preview deploy."
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          NUMBER=$(jq -r '.number' <<< "$PR_JSON")
+          AUTHOR=$(jq -r '.author.login' <<< "$PR_JSON")
+          CROSS_REPO=$(jq -r '.isCrossRepository' <<< "$PR_JSON")
+          if [ "$CROSS_REPO" = "true" ] || [ "$AUTHOR" = "dependabot[bot]" ]; then
+            echo "Pull request #$NUMBER is from a fork or Dependabot; skipping preview deploy."
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "eligible=true"
+            echo "number=$NUMBER"
+            echo "url=https://markafitzgerald1.github.io/cribbage-trainer/pr/$NUMBER/"
+          } >> "$GITHUB_OUTPUT"
+
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: [build-and-test, resolve-preview-pr]
+    if: github.ref != 'refs/heads/main' && needs.resolve-preview-pr.outputs.eligible == 'true'
+
+    # Shared with build-upload-and-deploy; see that job's comment.
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
+
+    permissions:
+      contents: write # to push the pages-content state branch
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    # A separate, unprotected environment from github-pages: that
+    # environment's branch policy permits deployments only from main.
+    environment:
+      name: github-pages-preview
+      url: ${{ needs.resolve-preview-pr.outputs.url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js and cache npm dependencies
+        uses: actions/setup-node@v4
         with:
-          token: ${{ github.token }}
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm clean-install
+
+      - name: Build web application bundle for this preview
+        run: npm run build
+        env:
+          PAGES_BASE_PATH: /cribbage-trainer/pr/${{ needs.resolve-preview-pr.outputs.number }}
+          VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ vars.VITE_GOOGLE_ANALYTICS_MEASUREMENT_ID }}
+
+      - name: Publish preview content and deploy
+        uses: ./.github/actions/publish-pages-content
+        with:
+          merge-args: pr ${{ needs.resolve-preview-pr.outputs.number }} dist
+          commit-message: Publish pr/${{ needs.resolve-preview-pr.outputs.number }} preview

--- a/.github/workflows/pages-preview-cleanup.yml
+++ b/.github/workflows/pages-preview-cleanup.yml
@@ -40,7 +40,20 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      # If the content store has never been created there is no preview to
+      # remove, and publishing an empty tree would take production down.
+      - id: store-exists
+        name: Check whether the pages-content store exists
+        run: |
+          if git ls-remote --exit-code --heads origin pages-content > /dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No pages-content branch; nothing to clean up."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Remove preview content and deploy
+        if: steps.store-exists.outputs.exists == 'true'
         uses: ./.github/actions/publish-pages-content
         with:
           merge-args: remove ${{ github.event.pull_request.number }}

--- a/.github/workflows/pages-preview-cleanup.yml
+++ b/.github/workflows/pages-preview-cleanup.yml
@@ -1,0 +1,47 @@
+name: pages-preview-cleanup
+on:
+  pull_request:
+    types: [closed]
+
+# Kept in its own file, separate from
+# npm-build-test-upload-artifact-and-deploy.yml, so editing this cleanup
+# logic can never perturb the on:/if: conditions of the production-critical
+# build-and-test and build-upload-and-deploy jobs there.
+jobs:
+  remove-preview:
+    runs-on: ubuntu-latest
+    # Same-repository, non-Dependabot PRs only: those are the only PRs that
+    # deploy-preview ever publishes a pr/<number>/ directory for.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+
+    # Shared with build-upload-and-deploy and deploy-preview in the main
+    # workflow so no two Pages-publishing jobs can race on the
+    # pages-content state branch.
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
+
+    permissions:
+      contents: write # to push the pages-content state branch
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages-preview
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Remove preview content and deploy
+        uses: ./.github/actions/publish-pages-content
+        with:
+          merge-args: remove ${{ github.event.pull_request.number }}
+          commit-message: Remove pr/${{ github.event.pull_request.number }} preview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,9 +381,41 @@
 
 - Workflow: .github/workflows/npm-build-test-upload-artifact-and-deploy.yml.
 - On non-main branches: builds Docker test image and runs Playwright e2e via
-  `npm run docker:run-e2e-only`.
+  `npm run docker:run-e2e-only`, then (same workflow) resolves whether an
+  open, same-repository, non-Dependabot PR exists for the branch and, if so,
+  publishes a PR preview.
 - On main: installs deps from `.nvmrc`, builds app and Storybook, uploads Pages
   artifact, deploys to GitHub Pages.
+
+## PR preview deploys (issue #153)
+
+- Every eligible open PR auto-publishes to
+  `https://markafitzgerald1.github.io/cribbage-trainer/pr/<number>/`, kept
+  current on every push and removed when the PR closes
+  (`.github/workflows/pages-preview-cleanup.yml`, triggered by
+  `pull_request: closed`, kept in its own file so editing cleanup logic can
+  never perturb the production-critical jobs' `on:`/`if:` conditions).
+  "Eligible" means same-repository and not authored by `dependabot[bot]`;
+  fork PRs never reach this at all since `push` never fires in this repo for
+  fork commits.
+- The `pages-content` branch is a git-based **cache**, not the Pages
+  publishing source (Pages settings stay `build_type: workflow`). It is
+  fetched-or-created, mutated, and force-pushed as a single amended commit
+  by every publish (`.github/actions/publish-pages-content`), so its history
+  never grows — don't "clean up" this branch or its lack of history; that is
+  intentional. It holds the production site root plus one `pr/<number>/`
+  directory per currently-open preview; the merge/replace/remove logic lives
+  in `scripts/pagesContentMerge.mjs` (tested via `node --test`, not Jest, so
+  it stays outside `src/**` and the 100% Jest coverage threshold).
+- There are deliberately **two** GitHub Pages environments: `github-pages`
+  (production) has a branch policy restricting it to `main` — reusing it for
+  previews would silently hang every preview job before any step runs.
+  Preview jobs target the separate, unprotected `github-pages-preview`
+  environment instead, which Actions auto-creates on first use.
+- `vite.config.js`'s `base` reads `PAGES_BASE_PATH` (falling back to
+  `/cribbage-trainer`); preview builds set it to `/cribbage-trainer/pr/<n>`
+  and deliberately skip the `dist/`-caching step used on main, since that
+  cache key hashes only source files, not the base path.
 
 ## Contribution notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,7 +397,10 @@
   never perturb the production-critical jobs' `on:`/`if:` conditions).
   "Eligible" means same-repository and not authored by `dependabot[bot]`;
   fork PRs never reach this at all since `push` never fires in this repo for
-  fork commits.
+  fork commits. Because previews are `push`-triggered, the branch-creating
+  push always precedes `gh pr create` and skips with "No open pull request
+  found"; the first preview publishes on the first push made _after_ the PR
+  exists (push an empty or follow-up commit if one is needed sooner).
 - The `pages-content` branch is a git-based **cache**, not the Pages
   publishing source (Pages settings stay `build_type: workflow`). It is
   fetched-or-created, mutated, and force-pushed as a single amended commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,6 +421,11 @@
   does not exist. If the guard ever fires, seed production first (deploy
   `main` through the new workflow, or apply the `prod` mutation to the
   branch manually).
+- Never retry a failed Pages deploy with a single-job rerun: rerunning a
+  job that already uploaded a `github-pages` artifact adds a second one to
+  the same run, and `actions/deploy-pages` then always fails with
+  "Multiple artifacts named github-pages" — for every attempt on that run.
+  Push a new commit (fresh run) instead.
 - There are deliberately **two** GitHub Pages environments: `github-pages`
   (production) has a branch policy restricting it to `main` — reusing it for
   previews would silently hang every preview job before any step runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,17 @@
   directory per currently-open preview; the merge/replace/remove logic lives
   in `scripts/pagesContentMerge.mjs` (tested via `node --test`, not Jest, so
   it stays outside `src/**` and the 100% Jest coverage threshold).
+- Every publish deploys the **whole** merged tree, so a `pages-content`
+  checkout lacking a root `index.html` must never reach `deploy-pages`: the
+  very first preview publish did exactly that (the branch bootstraps empty
+  and production had never been seeded through this pipeline) and took the
+  production site down. The composite action now runs
+  `pagesContentMerge.mjs assert-deployable` before deploying, `applyProd`
+  preserves the checkout's `.git` worktree pointer (deleting it breaks the
+  commit-and-push step), and the cleanup workflow no-ops when the branch
+  does not exist. If the guard ever fires, seed production first (deploy
+  `main` through the new workflow, or apply the `prod` mutation to the
+  branch manually).
 - There are deliberately **two** GitHub Pages environments: `github-pages`
   (production) has a branch policy restricting it to `main` — reusing it for
   previews would silently hang every preview job before any step runs.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -295,6 +295,9 @@ export default [
 
     languageOptions: {
       ecmaVersion: 2022,
+      globals: {
+        process: "readonly",
+      },
       parser: espree,
       sourceType: "module",
     },

--- a/jest.config.json
+++ b/jest.config.json
@@ -21,7 +21,12 @@
     "\\.module\\.css$": "<rootDir>/__mocks__/styleMock.ts"
   },
   "testEnvironment": "jsdom",
-  "testPathIgnorePatterns": ["/.claude/", "/tests-e2e/", "/tests-examples"],
+  "testPathIgnorePatterns": [
+    "/.claude/",
+    "/scripts/",
+    "/tests-e2e/",
+    "/tests-examples"
+  ],
   "transform": {
     "^.+\\.tsx?$": "babel-jest"
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "deps:update:minor": "npx npm-check-updates --target minor -u && npm install",
     "table:update": "node scripts/updateExpectedPointsTables.mjs",
     "table:update:crib": "node scripts/updateExpectedCribPointsTable.mjs",
-    "table:update:play": "node scripts/updateExpectedPlayPointsTable.mjs"
+    "table:update:play": "node scripts/updateExpectedPlayPointsTable.mjs",
+    "test:pages-content-merge": "node --test scripts/pagesContentMerge.test.mjs"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/scripts/pagesContentMerge.mjs
+++ b/scripts/pagesContentMerge.mjs
@@ -1,4 +1,4 @@
-import { cpSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
 
 // Validated so a PR number sourced from external input (gh pr list JSON)
@@ -15,13 +15,18 @@ function prDirectory(checkoutDir, prNumber) {
   return path.join(checkoutDir, "pr", String(prNumber));
 }
 
+// The pr/ directory holds the other currently-open preview deploys; .git
+// must survive because the checkout is a live git worktree that gets
+// committed and pushed after the mutation.
+const PRESERVED_CHECKOUT_ENTRIES = new Set(["pr", ".git"]);
+
 // Replaces everything in checkoutDir with distDir's contents except the
-// pr/ directory, which holds the other currently-open preview deploys.
+// preserved entries above.
 export function applyProd(distDir, checkoutDir) {
   mkdirSync(checkoutDir, { recursive: true });
 
   for (const entry of readdirSync(checkoutDir)) {
-    if (entry !== "pr") {
+    if (!PRESERVED_CHECKOUT_ENTRIES.has(entry)) {
       rmSync(path.join(checkoutDir, entry), { force: true, recursive: true });
     }
   }
@@ -45,6 +50,20 @@ export function removePr(prNumber, checkoutDir) {
   rmSync(prDirectory(checkoutDir, prNumber), { force: true, recursive: true });
 }
 
+// Deploying replaces the entire live Pages site with checkoutDir, so a
+// tree without a production root index.html would take production down
+// (this happened on the pages-content branch's very first preview
+// publish, before production had ever been seeded through this pipeline).
+export function assertDeployable(checkoutDir) {
+  if (!existsSync(path.join(checkoutDir, "index.html"))) {
+    throw new Error(
+      `Refusing to deploy: ${checkoutDir} has no root index.html, so ` +
+        "deploying would replace the live production site with an " +
+        "incomplete tree. Seed production content first (deploy main).",
+    );
+  }
+}
+
 function main(argv) {
   const [command, ...rest] = argv;
 
@@ -60,9 +79,14 @@ function main(argv) {
     const [prNumber, checkoutDir] = rest;
 
     removePr(prNumber, checkoutDir);
+  } else if (command === "assert-deployable") {
+    const [checkoutDir] = rest;
+
+    assertDeployable(checkoutDir);
   } else {
     throw new Error(
-      `Unknown command: ${command}. Expected "prod", "pr", or "remove".`,
+      `Unknown command: ${command}. Expected "prod", "pr", "remove", ` +
+        `or "assert-deployable".`,
     );
   }
 }

--- a/scripts/pagesContentMerge.mjs
+++ b/scripts/pagesContentMerge.mjs
@@ -1,0 +1,72 @@
+import { cpSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import path from "node:path";
+
+// Validated so a PR number sourced from external input (gh pr list JSON)
+// can never be used to escape the intended pr/<number> directory.
+function assertValidPrNumber(prNumber) {
+  if (!/^\d+$/u.test(String(prNumber))) {
+    throw new Error(`Invalid PR number: ${prNumber}`);
+  }
+}
+
+function prDirectory(checkoutDir, prNumber) {
+  assertValidPrNumber(prNumber);
+
+  return path.join(checkoutDir, "pr", String(prNumber));
+}
+
+// Replaces everything in checkoutDir with distDir's contents except the
+// pr/ directory, which holds the other currently-open preview deploys.
+export function applyProd(distDir, checkoutDir) {
+  mkdirSync(checkoutDir, { recursive: true });
+
+  for (const entry of readdirSync(checkoutDir)) {
+    if (entry !== "pr") {
+      rmSync(path.join(checkoutDir, entry), { force: true, recursive: true });
+    }
+  }
+
+  cpSync(distDir, checkoutDir, { recursive: true });
+}
+
+// Replaces only pr/<prNumber>/, leaving the production root and every
+// other PR's preview untouched.
+export function applyPr(prNumber, distDir, checkoutDir) {
+  const target = prDirectory(checkoutDir, prNumber);
+
+  rmSync(target, { force: true, recursive: true });
+  mkdirSync(target, { recursive: true });
+  cpSync(distDir, target, { recursive: true });
+}
+
+// A no-op (not a throw) when the PR has no preview, e.g. it never had a
+// push land after opening, or cleanup runs twice.
+export function removePr(prNumber, checkoutDir) {
+  rmSync(prDirectory(checkoutDir, prNumber), { force: true, recursive: true });
+}
+
+function main(argv) {
+  const [command, ...rest] = argv;
+
+  if (command === "prod") {
+    const [distDir, checkoutDir] = rest;
+
+    applyProd(distDir, checkoutDir);
+  } else if (command === "pr") {
+    const [prNumber, distDir, checkoutDir] = rest;
+
+    applyPr(prNumber, distDir, checkoutDir);
+  } else if (command === "remove") {
+    const [prNumber, checkoutDir] = rest;
+
+    removePr(prNumber, checkoutDir);
+  } else {
+    throw new Error(
+      `Unknown command: ${command}. Expected "prod", "pr", or "remove".`,
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/scripts/pagesContentMerge.test.mjs
+++ b/scripts/pagesContentMerge.test.mjs
@@ -1,0 +1,127 @@
+import { applyPr, applyProd, removePr } from "./pagesContentMerge.mjs";
+import { deepStrictEqual, ok } from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { tmpdir } from "node:os";
+
+function makeTempDir() {
+  return mkdtempSync(path.join(tmpdir(), "pages-content-merge-test-"));
+}
+
+function writeFile(filePath, contents) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+}
+
+function readFile(filePath) {
+  return readFileSync(filePath, "utf8");
+}
+
+function seedCheckout(checkoutDir) {
+  writeFile(path.join(checkoutDir, "index.html"), "old prod");
+  writeFile(path.join(checkoutDir, "pr", "7", "index.html"), "pr 7 preview");
+  writeFile(path.join(checkoutDir, "pr", "42", "index.html"), "pr 42 preview");
+}
+
+function previewExists(directoryPath) {
+  try {
+    readFileSync(path.join(directoryPath, "index.html"));
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("applyProd replaces the root but preserves every pr/ directory", () => {
+  const checkoutDir = makeTempDir();
+  const distDir = makeTempDir();
+
+  try {
+    seedCheckout(checkoutDir);
+    writeFile(path.join(distDir, "index.html"), "new prod");
+
+    applyProd(distDir, checkoutDir);
+
+    deepStrictEqual(readFile(path.join(checkoutDir, "index.html")), "new prod");
+    deepStrictEqual(
+      readFile(path.join(checkoutDir, "pr", "7", "index.html")),
+      "pr 7 preview",
+    );
+    deepStrictEqual(
+      readFile(path.join(checkoutDir, "pr", "42", "index.html")),
+      "pr 42 preview",
+    );
+  } finally {
+    rmSync(checkoutDir, { force: true, recursive: true });
+    rmSync(distDir, { force: true, recursive: true });
+  }
+});
+
+test("applyPr replaces only its own pr/<number>/ directory", () => {
+  const checkoutDir = makeTempDir();
+  const distDir = makeTempDir();
+
+  try {
+    seedCheckout(checkoutDir);
+    writeFile(path.join(distDir, "index.html"), "pr 42 updated");
+
+    applyPr(42, distDir, checkoutDir);
+
+    deepStrictEqual(readFile(path.join(checkoutDir, "index.html")), "old prod");
+    deepStrictEqual(
+      readFile(path.join(checkoutDir, "pr", "7", "index.html")),
+      "pr 7 preview",
+    );
+    deepStrictEqual(
+      readFile(path.join(checkoutDir, "pr", "42", "index.html")),
+      "pr 42 updated",
+    );
+  } finally {
+    rmSync(checkoutDir, { force: true, recursive: true });
+    rmSync(distDir, { force: true, recursive: true });
+  }
+});
+
+test("removePr deletes only the closed PR's directory", () => {
+  const checkoutDir = makeTempDir();
+
+  try {
+    seedCheckout(checkoutDir);
+
+    removePr(42, checkoutDir);
+
+    ok(!previewExists(path.join(checkoutDir, "pr", "42")));
+    deepStrictEqual(
+      readFile(path.join(checkoutDir, "pr", "7", "index.html")),
+      "pr 7 preview",
+    );
+    deepStrictEqual(readFile(path.join(checkoutDir, "index.html")), "old prod");
+  } finally {
+    rmSync(checkoutDir, { force: true, recursive: true });
+  }
+});
+
+test("removePr on a PR with no existing preview is a no-op, not a throw", () => {
+  const checkoutDir = makeTempDir();
+
+  try {
+    seedCheckout(checkoutDir);
+
+    removePr(999, checkoutDir);
+
+    deepStrictEqual(
+      readFile(path.join(checkoutDir, "pr", "7", "index.html")),
+      "pr 7 preview",
+    );
+  } finally {
+    rmSync(checkoutDir, { force: true, recursive: true });
+  }
+});

--- a/scripts/pagesContentMerge.test.mjs
+++ b/scripts/pagesContentMerge.test.mjs
@@ -1,5 +1,10 @@
-import { applyPr, applyProd, removePr } from "./pagesContentMerge.mjs";
-import { deepStrictEqual, ok } from "node:assert/strict";
+import {
+  applyPr,
+  applyProd,
+  assertDeployable,
+  removePr,
+} from "./pagesContentMerge.mjs";
+import { deepStrictEqual, doesNotThrow, ok, throws } from "node:assert/strict";
 import {
   mkdirSync,
   mkdtempSync,
@@ -106,6 +111,46 @@ test("removePr deletes only the closed PR's directory", () => {
     deepStrictEqual(readFile(path.join(checkoutDir, "index.html")), "old prod");
   } finally {
     rmSync(checkoutDir, { force: true, recursive: true });
+  }
+});
+
+test("applyProd preserves the checkout's .git worktree pointer", () => {
+  const checkoutDir = makeTempDir();
+  const distDir = makeTempDir();
+
+  try {
+    seedCheckout(checkoutDir);
+    writeFile(path.join(checkoutDir, ".git"), "gitdir: /somewhere/else");
+    writeFile(path.join(distDir, "index.html"), "new prod");
+
+    applyProd(distDir, checkoutDir);
+
+    deepStrictEqual(
+      readFile(path.join(checkoutDir, ".git")),
+      "gitdir: /somewhere/else",
+    );
+  } finally {
+    rmSync(checkoutDir, { force: true, recursive: true });
+    rmSync(distDir, { force: true, recursive: true });
+  }
+});
+
+test("assertDeployable rejects a tree without a production root", () => {
+  const checkoutDir = makeTempDir();
+  const distDir = makeTempDir();
+
+  try {
+    writeFile(path.join(distDir, "index.html"), "pr-only preview");
+    applyPr(661, distDir, checkoutDir);
+
+    throws(() => assertDeployable(checkoutDir), /no root index\.html/u);
+
+    applyProd(distDir, checkoutDir);
+
+    doesNotThrow(() => assertDeployable(checkoutDir));
+  } finally {
+    rmSync(checkoutDir, { force: true, recursive: true });
+    rmSync(distDir, { force: true, recursive: true });
   }
 });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,9 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/writing-tests/integrations/vitest-addon
 export default {
-  base: "/cribbage-trainer",
+  // Overridden for PR preview deploys, which publish under
+  // /cribbage-trainer/pr/<number>/ (see .github/workflows).
+  base: process.env.PAGES_BASE_PATH ?? "/cribbage-trainer",
   build: {
     emptyOutDir: true,
     outDir: "../dist",


### PR DESCRIPTION
## Summary

- Every eligible open PR (same-repository, non-Dependabot) now auto-publishes to `https://markafitzgerald1.github.io/cribbage-trainer/pr/<number>/`, updated on each push and removed when the PR closes, without disturbing the production deploy at the site root.
- **Live preview for this PR: <https://markafitzgerald1.github.io/cribbage-trainer/pr/661/>** (also linked from this PR's `github-pages-preview` deployment status).
- A `pages-content` git branch acts as a persistent cache between ephemeral runners (production root plus one `pr/<number>/` per currently-open preview); a single commit is amended and force-pushed on every publish so the branch's history never grows. Production, preview, and cleanup all publish through a shared `publish-pages-content` composite action and a shared `pages-deploy` concurrency group so two deploys can never race.
- Previews use a new, unprotected `github-pages-preview` GitHub Pages environment — the existing `github-pages` environment's branch policy restricts deploys to `main`, which would otherwise silently block every preview.
- `vite.config.js`'s base path is now overridable via `PAGES_BASE_PATH` for preview builds.
- Hardening added after the first live run took production down (see the incident comment below): an `assert-deployable` guard refuses to deploy any merged tree lacking a root `index.html`, `applyProd` preserves the checkout's `.git` worktree pointer, and the cleanup workflow no-ops when `pages-content` does not exist.

Closes #153.

## Learnings captured

Added to `AGENTS.md` under a new "PR preview deploys" section: the two-environment split and why, the amend-and-force-push design for the state branch, why preview builds skip the existing `dist/`-caching step (its cache key doesn't account for `PAGES_BASE_PATH`), the first-push-precedes-PR-creation gap, the bootstrap/production-seeding requirement behind the `assert-deployable` guard, and never retrying a failed Pages deploy via single-job rerun (it poisons the run with a duplicate `github-pages` artifact).

## Test plan

- [x] `npm run lint:actionlint` (incl. embedded shellcheck) passes on both workflow files.
- [x] `node --test scripts/pagesContentMerge.test.mjs` covers production preservation, preview replacement, close cleanup, `.git` worktree-pointer preservation, and the `assert-deployable` guard.
- [x] Local dry run: built with `PAGES_BASE_PATH=/cribbage-trainer/pr/999`, assembled a simulated `<root>/cribbage-trainer/pr/999/` tree with the merge script, served it, and confirmed JS/CSS/manifest/table-chunk assets all resolve under the nested path; confirmed a subsequent production merge preserves that preview directory.
- [x] `npm run docker:build-and-test-all` (build, full lint suite, 485 Jest tests at 100% coverage, Storybook coverage, 117 Playwright e2e) passes clean.
- [x] Real end-to-end proof on this PR's own Actions runs: `deploy-preview` runs after `build-and-test`, the `pages-content` branch was created on first use, the PR exposes a `github-pages-preview` deployment link, and production root, `/storybook/`, and `/pr/661/` all serve correct per-base-path assets.
- [x] On merge/close: confirm `remove-preview` deletes `/pr/661/` and production is unaffected, and that main's first run through the new workflow publishes production via `pages-content`.