### PR TITLE
Fix Dependabot preview guard and document deletion ruleset

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,6 +11,7 @@
     "camelcase",
     "discardable",
     "elif",
+    "esac",
     "espree",
     "fieldset",
     "figcaption",

--- a/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
@@ -155,9 +155,15 @@ jobs:
             exit 0
           fi
           NUMBER=$(jq -r '.number' <<< "$PR_JSON")
+          # The same bot is app/dependabot in gh CLI/GraphQL output but
+          # dependabot[bot] in REST event payloads; match both spellings.
           AUTHOR=$(jq -r '.author.login' <<< "$PR_JSON")
           CROSS_REPO=$(jq -r '.isCrossRepository' <<< "$PR_JSON")
-          if [ "$CROSS_REPO" = "true" ] || [ "$AUTHOR" = "dependabot[bot]" ]; then
+          case "$AUTHOR" in
+            "dependabot[bot]" | "app/dependabot") DEPENDABOT=true ;;
+            *) DEPENDABOT=false ;;
+          esac
+          if [ "$CROSS_REPO" = "true" ] || [ "$DEPENDABOT" = "true" ]; then
             echo "Pull request #$NUMBER is from a fork or Dependabot; skipping preview deploy."
             echo "eligible=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/pages-preview-cleanup.yml
+++ b/.github/workflows/pages-preview-cleanup.yml
@@ -10,11 +10,12 @@ on:
 jobs:
   remove-preview:
     runs-on: ubuntu-latest
-    # Same-repository, non-Dependabot PRs only: those are the only PRs that
-    # deploy-preview ever publishes a pr/<number>/ directory for.
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+    # Same-repository PRs only (fork PRs never get a preview). No author
+    # filter: removing a directory that was never published is a no-op, and
+    # excluding authors here risks stranding a preview if the publish-side
+    # filter and this one ever disagree on a bot's login spelling
+    # (app/dependabot in gh CLI output vs dependabot[bot] in event payloads).
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     # Shared with build-upload-and-deploy and deploy-preview in the main
     # workflow so no two Pages-publishing jobs can race on the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,6 +427,11 @@
   the same run, and `actions/deploy-pages` then always fails with
   "Multiple artifacts named github-pages" — for every attempt on that run.
   Push a new commit (fresh run) instead.
+- Bot logins are spelled differently per GitHub API surface: Dependabot is
+  `app/dependabot` in `gh` CLI/GraphQL author fields but `dependabot[bot]`
+  in REST/webhook event payloads. Never compare a single literal — the
+  preview-eligibility check matched only the latter and silently published
+  a preview for a Dependabot PR.
 - There are deliberately **two** GitHub Pages environments: `github-pages`
   (production) has a branch policy restricting it to `main` — reusing it for
   previews would silently hang every preview job before any step runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,7 +406,8 @@
   fetched-or-created, mutated, and force-pushed as a single amended commit
   by every publish (`.github/actions/publish-pages-content`), so its history
   never grows — don't "clean up" this branch or its lack of history; that is
-  intentional. It holds the production site root plus one `pr/<number>/`
+  intentional, and a repository ruleset ("Protect pages-content from
+  deletion") blocks deleting it. It holds the production site root plus one `pr/<number>/`
   directory per currently-open preview; the merge/replace/remove logic lives
   in `scripts/pagesContentMerge.mjs` (tested via `node --test`, not Jest, so
   it stays outside `src/**` and the 100% Jest coverage threshold).


### PR DESCRIPTION
## Summary

Follow-up to #661, found while auditing the first overnight of real preview traffic (replaces #663, which was accidentally based on the pre-squash feature branch):

- **Dependabot exclusion was silently broken**: `gh pr list` reports bot authors as `app/dependabot`, while REST event payloads use `dependabot[bot]`; the eligibility check compared only the latter literal, so Dependabot PR #656 was published to `/pr/656/`. The publish-side guard now matches both spellings.
- **Cleanup no longer filters by author**: removing a never-published directory is already a no-op, and an author filter there could strand a preview whenever the two sides disagree on a bot's login spelling — as they just did. Same-repository remains the only condition, so `/pr/656/` gets cleaned up automatically when that PR closes.
- Documents the new "Protect pages-content from deletion" repository ruleset and the bot-login-spelling gotcha in `AGENTS.md`.

## Learnings captured

`AGENTS.md`: bot logins are spelled differently per GitHub API surface (`app/dependabot` vs `dependabot[bot]`) — never compare a single literal; plus the pages-content deletion-ruleset note.

## Test plan

- [x] `npm run lint:actionlint`, prettier, cspell, markdownlint pass on the changed files.
- [x] This PR's own `deploy-preview` run exercises the fixed guard path end-to-end (human-authored PR publishes normally).
- [x] Next Dependabot branch push after merge: `deploy-preview` skips with "from a fork or Dependabot".
- [x] When Dependabot PR #656 closes: `remove-preview` runs (no longer author-filtered) and `/pr/656/` disappears.
