### PR TITLE
Ignore incompatible ESLint 10 releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,11 @@ updates:
         patterns:
           - "*"
     ignore:
+      # Bounded to the current release (not >=10) so the ignore ages out and
+      # prompts a periodic compatibility re-check. Blocked by the latest
+      # eslint-plugin-jsx-a11y peer range, which ends at ESLint 9.
       - dependency-name: "eslint"
-        versions: [">=10.0.0 <=10.4.0"]
+        versions: [">=10.0.0 <=10.7.0"]
       # Bounded to the current release (not >=7) so the ignore ages out and
       # prompts a periodic compatibility re-check, matching the eslint entry.
       # Blocked by @typescript-eslint peer range (ERESOLVE in PR #662).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,11 @@
 
 - Keep dependencies current in PRs: include minor and patch bumps, and take major
   upgrades when they do not overshadow the PR's primary purpose.
+- Dependabot intentionally ignores ESLint 10.0.0 through 10.7.0 because the
+  latest `eslint-plugin-jsx-a11y` release (6.10.2) declares peer support only
+  through ESLint 9. Before changing that range, verify both packages' current
+  registry metadata; do not bypass the peer conflict with
+  `--legacy-peer-deps`.
 - Use `npm run deps:update:minor` for routine refreshes; handle larger major
   upgrades separately if they would dominate the change set.
 - When `npm run lint:audit` (better-npm-audit) fails on freshly published


### PR DESCRIPTION
## Summary

- Extend Dependabot's bounded ESLint exclusion from 10.4.0 through the current 10.7.0 release.
- Document why ESLint 10 remains blocked and how to re-check compatibility before changing the range.
- Follow up on #667 and the failed grouped dependency update in #668.

## Why

The npm registry currently reports ESLint 10.7.0 as latest and `eslint-plugin-jsx-a11y` 6.10.2 as latest. That plugin's declared ESLint peer range ends at ESLint 9, so the grouped update fails dependency installation when it selects ESLint 10.7.0.

The exclusion remains bounded rather than using `>=10`, so a future ESLint release will prompt another compatibility check instead of being hidden indefinitely.

## Learnings captured

`AGENTS.md` records the current peer-dependency incompatibility, the bounded-ignore rationale, and the registry checks required before relaxing or extending the range.

## Validation

- `npm view eslint version` returned `10.7.0`.
- `npm view eslint-plugin-jsx-a11y version peerDependencies --json` returned version `6.10.2` with ESLint support through `^9` only.
- Prettier, cspell, markdownlint, actionlint, and `git diff --check` pass.
- `npm run docker:build-and-test-all` passes on the final diff, including 117/117 Playwright tests.

## Test plan

- [ ] Dependabot configuration is valid according to its GitHub check.
- [ ] After merge, recreate the npm-all update and verify it excludes ESLint 10.7.0 and TypeScript 7.0.2, then confirm CI passes or identify any remaining independently incompatible major update.

Authored by OpenAI Codex.
