### PR TITLE
Make loader generic compatible with Babel 8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,13 @@
   through ESLint 9. Before changing that range, verify both packages' current
   registry metadata; do not bypass the peer conflict with
   `--legacy-peer-deps`.
+- With Babel's React and TypeScript presets enabled together, avoid single
+  unconstrained generic arrow functions such as `<T>(...) => ...` in `.ts`
+  files: Babel 8 parses the type parameter as JSX, while the repo's current
+  Prettier removes the TSX-style disambiguating comma from `.ts`, and lint
+  rejects a neutral `extends unknown` constraint. Prefer a named generic
+  function expression or declaration, which both Babel generations parse
+  consistently without weakening quality gates.
 - Use `npm run deps:update:minor` for routine refreshes; handle larger major
   upgrades separately if they would dominate the change set.
 - When `npm run lint:audit` (better-npm-audit) fails on freshly published

--- a/src/game/expectedPointsTableLoader.ts
+++ b/src/game/expectedPointsTableLoader.ts
@@ -8,39 +8,40 @@ export interface ExpectedPointsTableLoader<T> {
   readonly setTableSync: (newTable: T | null) => void;
 }
 
-export const createExpectedPointsTableLoader = <T>(
-  importTable: () => Promise<ImportedTable>,
-): ExpectedPointsTableLoader<T> => {
-  let table: T | null = null;
-  let loadPromise: Promise<T> | null = null;
+export const createExpectedPointsTableLoader =
+  function createExpectedPointsTableLoader<T>(
+    importTable: () => Promise<ImportedTable>,
+  ): ExpectedPointsTableLoader<T> {
+    let table: T | null = null;
+    let loadPromise: Promise<T> | null = null;
 
-  const loadTable = (): Promise<T> => {
-    if (table !== null) {
-      return Promise.resolve(table);
-    }
-    if (!loadPromise) {
-      loadPromise = importTable()
-        .then((module) => {
-          table = module.default as T;
-          return table;
-        })
-        .catch(
-          /* istanbul ignore next */
-          (error) => {
-            loadPromise = null;
-            throw error as Error;
-          },
-        );
-    }
-    return loadPromise;
+    const loadTable = (): Promise<T> => {
+      if (table !== null) {
+        return Promise.resolve(table);
+      }
+      if (!loadPromise) {
+        loadPromise = importTable()
+          .then((module) => {
+            table = module.default as T;
+            return table;
+          })
+          .catch(
+            /* istanbul ignore next */
+            (error) => {
+              loadPromise = null;
+              throw error as Error;
+            },
+          );
+      }
+      return loadPromise;
+    };
+
+    const getTableSync = (): T | null => table;
+
+    const setTableSync = (newTable: T | null): void => {
+      table = newTable;
+      loadPromise = newTable === null ? null : Promise.resolve(newTable);
+    };
+
+    return { getTableSync, loadTable, setTableSync };
   };
-
-  const getTableSync = (): T | null => table;
-
-  const setTableSync = (newTable: T | null): void => {
-    table = newTable;
-    loadPromise = newTable === null ? null : Promise.resolve(newTable);
-  };
-
-  return { getTableSync, loadTable, setTableSync };
-};


### PR DESCRIPTION
## Summary

- Replace one JSX-ambiguous generic arrow function with a named generic function expression.
- Preserve the existing exported `const`, behavior, tests, and Storybook coverage thresholds.
- Document the Babel 8, Prettier, and lint interaction in `AGENTS.md`.

## Root cause

PR #671 upgrades the Babel toolchain from 7 to 8. With the repository's React and TypeScript presets enabled together, Babel 8 parses the loader's single unconstrained `<T>(...) => ...` type parameter as JSX and fails before seven Jest suites can run.

The usual TSX spelling `<T,>` is not durable here because the current Prettier removes that comma from a `.ts` file. A neutral `extends unknown` constraint is rejected by the repository's TypeScript lint rules. A named generic function expression is accepted by both Babel generations and every current quality gate.

## Validation

- Current main dependencies:
  - focused loader test: 6/6 pass;
  - ESLint, Prettier, cspell, markdownlint, TypeScript, and `git diff --check` pass;
  - `npm run docker:build-and-test-all` passes, including 117/117 Playwright tests with unchanged Storybook coverage thresholds.
- PR #671's exact Babel 8 lockfile plus this source change:
  - all 46 Jest suites and 485 tests pass at 100% coverage;
  - the combined Docker run proceeds past Babel/Jest and then exposes separate jscpd 5 and Prettier 3.9 upgrade work.

## Known follow-up

After this merges, rebase or recreate #671. Its Babel parser failure should be resolved; #671 will still need focused handling for jscpd 5 scanning `node_modules` and the formatting changes requested by Prettier 3.9 before #667's Test Plan item 2 can be marked complete.

## Learnings captured

`AGENTS.md` records the JSX ambiguity and why this repository should prefer a named generic function expression or declaration over the comma or redundant-constraint workarounds.

Authored by OpenAI Codex.
