### PR TITLE
ci: publish PR preview on PR open/reopen

### DIFF
--- a/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
+++ b/.github/workflows/npm-build-test-upload-artifact-and-deploy.yml
@@ -1,8 +1,19 @@
 name: npm-build-test-upload-artifact-and-deploy
-on: [push]
+on:
+  push:
+  # Publish a preview the moment a PR opens/reopens: the branch-creating
+  # push always precedes `gh pr create`, so a push-only trigger skips the
+  # first build with "No open pull request found" and leaves a fresh PR
+  # without a preview until the next push.
+  pull_request:
+    types: [opened, reopened]
 
+# Key on the branch (github.ref differs between the push and pull_request
+# events for the same branch: refs/heads/<branch> vs refs/pull/<n>/merge),
+# so a pull_request-opened run supersedes the branch's still-running push
+# run instead of racing it into a duplicate preview publish.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -163,8 +174,12 @@ jobs:
         name: Resolve the open, same-repository, non-Dependabot PR for this branch
         env:
           GH_TOKEN: ${{ github.token }}
+          # github.ref_name is <branch> on push but <n>/merge on
+          # pull_request; github.head_ref is the source branch only on
+          # pull_request events, so this resolves the branch on both.
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
-          BRANCH="${GITHUB_REF#refs/heads/}"
+          BRANCH="$BRANCH_NAME"
           # The --head filter prefix-matches branch names (github/cli#10816),
           # so select on exact headRefName equality to never publish this
           # branch's build to a similarly named branch's PR path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,6 +409,9 @@
 ## CI workflow notes
 
 - Workflow: .github/workflows/npm-build-test-upload-artifact-and-deploy.yml.
+  Triggers on `push` and on the `opened` and `reopened` `pull_request`
+  types (the latter so a new PR previews without a second push; see "PR
+  preview deploys").
 - On non-main branches: builds Docker test image and runs Playwright e2e via
   `npm run docker:run-e2e-only`, then (same workflow) resolves whether an
   open, same-repository, non-Dependabot PR exists for the branch and, if so,
@@ -424,12 +427,25 @@
   (`.github/workflows/pages-preview-cleanup.yml`, triggered by
   `pull_request: closed`, kept in its own file so editing cleanup logic can
   never perturb the production-critical jobs' `on:`/`if:` conditions).
-  "Eligible" means same-repository and not authored by `dependabot[bot]`;
-  fork PRs never reach this at all since `push` never fires in this repo for
-  fork commits. Because previews are `push`-triggered, the branch-creating
-  push always precedes `gh pr create` and skips with "No open pull request
-  found"; the first preview publishes on the first push made _after_ the PR
-  exists (push an empty or follow-up commit if one is needed sooner).
+  "Eligible" means same-repository and not authored by `dependabot[bot]`.
+  The workflow triggers on `push` and on the `opened` and `reopened`
+  `pull_request` types, so a fresh PR previews on open without waiting for a
+  second push: a push-only trigger skipped that first build because the
+  branch-creating push always precedes `gh pr create` ("No open pull request
+  found"). Same-repo `push` and `pull_request` events for one branch carry
+  different `github.ref`s (`refs/heads/<branch>` vs `refs/pull/<n>/merge`),
+  so the top-level `concurrency.group` keys on
+  `github.head_ref || github.ref_name` (the branch on both event types) to
+  make the opened run supersede the branch's still-running push run instead
+  of racing it into a duplicate publish. `resolve-preview-pr` resolves the
+  branch the same way (the `refs/heads/` strip yields `refs/pull/<n>/merge`
+  on `pull_request` events). Fork PRs now reach the workflow — `push` still
+  never fires for fork commits, but `pull_request` does — yet they run with a
+  read-only token and no secrets, and `resolve-preview-pr`'s
+  `isCrossRepository` check keeps them `eligible=false` so they never
+  publish. Only `opened` and `reopened` are subscribed, not `synchronize`:
+  in-PR commits already fire `push`, and the branch-keyed concurrency
+  collapses the two into one run.
 - The `pages-content` branch is a git-based **cache**, not the Pages
   publishing source (Pages settings stay `build_type: workflow`). It is
   fetched-or-created, mutated, and force-pushed as a single amended commit


### PR DESCRIPTION
## Problem

PR previews only published on the first `push` made *after* a PR existed.
Because the branch-creating push always precedes `gh pr create`, that first
push's `resolve-preview-pr` job found *"No open pull request found"* and
skipped, so a freshly opened PR had **no preview until another commit was
pushed**.

## Change

- **Trigger:** `on:` now also subscribes to `pull_request: types: [opened,
  reopened]`, so a preview publishes the moment a PR opens/reopens.
  `synchronize` is intentionally *not* subscribed — in-PR commits already fire
  `push`.
- **Concurrency:** `push` and `pull_request` carry different `github.ref`s for
  the same branch (`refs/heads/<branch>` vs `refs/pull/<n>/merge`). The
  top-level concurrency group now keys on `github.head_ref || github.ref_name`
  (the branch on both event types) so an `opened` run **supersedes** the
  branch's still-running push run instead of racing it into a duplicate preview
  publish.
- **Branch resolution:** `resolve-preview-pr` derives the branch from
  `github.head_ref || github.ref_name` instead of stripping `refs/heads/` off
  `GITHUB_REF` (which would yield `refs/pull/<n>/merge` on `pull_request`
  events).
- Docs updated in `AGENTS.md` (CI workflow notes + PR preview deploys).

## Review guide

- `.github/workflows/npm-build-test-upload-artifact-and-deploy.yml` — the
  three-line `on:` block, the concurrency `group:` expression, and the
  `BRANCH_NAME` env in `resolve-preview-pr`. The `== / != 'refs/heads/main'`
  guards are deliberately unchanged: on `pull_request` events `github.ref` is
  `refs/pull/<n>/merge`, so production stays gated to `main` and preview jobs
  still run.
- Invariants preserved:
  - **Single artifact per run:** each run still has exactly one deploy path
    (`build-upload-and-deploy` on main, `deploy-preview` otherwise) → one
    `github-pages` artifact; branch-keyed concurrency prevents concurrent
    push+PR runs for one branch.
  - **Fork PRs never publish:** they now reach the workflow via `pull_request`
    (read-only token, no secrets), but `resolve-preview-pr`'s
    `isCrossRepository` check sets `eligible=false`, so `deploy-preview` is
    skipped.
  - Preview jobs still target `github-pages-preview`; `pages-deploy` job-level
    concurrency and `pages-preview-cleanup.yml` are untouched.

## Testing plan

- Static: `actionlint`, YAML parse, `prettier --check`, `markdownlint`, and
  `cspell` (no new dictionary words) all pass locally.
- Live (the point of this PR): opening **this** PR should publish a preview at
  https://markafitzgerald1.github.io/cribbage-trainer/pr/<number>/ **on open,
  with no extra push**. Confirm the `resolve-preview-pr` → `deploy-preview`
  jobs run on the `pull_request` `opened` event and that a subsequent normal
  push does not double-deploy (the branch-keyed concurrency group should show
  the superseding behavior).
- The Docker unit/e2e/Storybook suite is not affected by a workflow-YAML or
  doc change and was not re-run for this change; relevant workflow/lint checks
  were validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)